### PR TITLE
Add readme links to development tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ Make sure you have the latest version of the Xcode command line tools installed:
 
 `xcode-select --install`
 
-`bundle install`
+`bundle install` ([Bundler](https://bundler.io/))
 
-`pod install`
+`pod install` ([CocoaPods](https://cocoapods.org/))
 
 In case you are contributor and you have been added to repository with certificates, please use
 


### PR DESCRIPTION
This makes it easier to know where the CLI tools required for development can be installed from.