### PR TITLE
[iOS] Bug when with the comments / highlights disappear when rotating iPad

### DIFF
--- a/Sabbath School/Read/Controller/ReadController.swift
+++ b/Sabbath School/Read/Controller/ReadController.swift
@@ -418,6 +418,12 @@ class ReadController: VideoPlaybackDelegatable {
             self.collectionNode.scrollToPage(at: self.lastPage ?? 1, animated: false)
             self.isTransitionInProgress = false
         }
+
+        if Helper.isPad {
+            highlights.forEach { highlight in
+                setHighlights(highlights: highlight)
+            }
+        }
     }
     
     override var previewActionItems: [UIPreviewActionItem] {
@@ -505,6 +511,10 @@ extension ReadController: ReadControllerProtocol {
     }
     
     func setHighlights(highlights: ReadHighlights) {
+        if Helper.isPad {
+            self.highlights.append(highlights)
+        }
+        
         if let index = self.reads.firstIndex(where: { $0.index == highlights.readIndex }) {
             if let readView = self.collectionNode.nodeForPage(at: index) as? ReadView {
                 readView.highlights = highlights
@@ -603,6 +613,10 @@ extension ReadController: ReadViewOutputProtocol {
     }
 
     func didReceiveHighlights(readHighlights: ReadHighlights) {
+        if Helper.isPad {
+            highlights.append(readHighlights)
+        }
+        
         presenter?.interactor?.saveHighlights(highlights: readHighlights)
     }
 

--- a/Sabbath School/Read/Controller/ReadController.swift
+++ b/Sabbath School/Read/Controller/ReadController.swift
@@ -423,6 +423,22 @@ class ReadController: VideoPlaybackDelegatable {
             highlights.forEach { highlight in
                 setHighlights(highlights: highlight)
             }
+            
+            comments.forEach { comment in
+                setComments(comments: comment)
+            }
+        }
+    }
+    
+    private func updateCommentsListWhenRotateIpad(readComments: ReadComments) {
+        if Helper.isPad {
+            if !comments.filter({ $0.readIndex == readComments.readIndex }).isEmpty {
+                for (i, comment) in comments.enumerated() where comment.readIndex == readComments.readIndex {
+                    comments[i] = readComments
+                }
+            } else {
+                comments.append(readComments)
+            }
         }
     }
     
@@ -527,6 +543,9 @@ extension ReadController: ReadControllerProtocol {
         if let index = self.reads.firstIndex(where: { $0.index == comments.readIndex }) {
             if let readView = self.collectionNode.nodeForPage(at: index) as? ReadView {
                 readView.comments = comments
+                if !comments.comments.isEmpty {
+                    updateCommentsListWhenRotateIpad(readComments: comments)
+                }
                 for comment in comments.comments {
                     readView.webView.setComment(comment)
                 }
@@ -621,6 +640,7 @@ extension ReadController: ReadViewOutputProtocol {
     }
 
     func didReceiveComment(readComments: ReadComments) {
+        updateCommentsListWhenRotateIpad(readComments: readComments)
         presenter?.interactor?.saveComments(comments: readComments)
     }
 


### PR DESCRIPTION
# What did you change:

- Keeping highlights and comments when rotate iPad

# Screenshot/GIFs of this change
![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/16100712/153310341-b09a9f81-a1d1-47bd-b411-3927b09beae9.gif)


# Merge checklist

- [ ] Automated (unit/ui) tests
- [x] Manual tests