### PR TITLE
Currently if device is in dark mode and reading options are set to Light then selection is not visible

### DIFF
--- a/Sabbath School/Read/View/ReadView.swift
+++ b/Sabbath School/Read/View/ReadView.swift
@@ -140,6 +140,7 @@ class ReadView: ASCellNode {
         webView.scrollView.backgroundColor = .clear
         webView.scrollView.contentInset = UIEdgeInsets(top: initialCoverHeight, left: 0, bottom: 0, right: 0)
         webView.scrollView.contentOffset.y = -self.parallaxCoverHeight
+        webView.tintColor = .systemBlue
         // webView.scrollView.setNeedsLayout()
 
         webView.readerViewDelegate = self


### PR DESCRIPTION
# What did you change:

- Set default tintColor to WKWebView fixed issue, keeping same behavior as before.

# Merge checklist

- [ ] Automated (unit/ui) tests
- [x] Manual tests