### PR TITLE
When user is playing some media and open the SSA it pause her media execution

### DIFF
--- a/Sabbath School/Audio/AudioPlayback.swift
+++ b/Sabbath School/Audio/AudioPlayback.swift
@@ -58,7 +58,7 @@ class AudioPlayback: NSObject {
     static func configure() {
         try? AVAudioSession.sharedInstance().setMode(.default)
         try? AVAudioSession.sharedInstance().setCategory(.playback)
-        try? AVAudioSession.sharedInstance().setActive(true, options: .notifyOthersOnDeactivation)
+        
         AudioPlayback.shared.remoteCommands = [
             .play,
             .pause,


### PR DESCRIPTION
# What did you change:

- Removing unnecessary code that stops other media when app start (https://developer.apple.com/documentation/avfaudio/avaudiosession/setactiveoptions/1616603-notifyothersondeactivation)

# Merge checklist

- [ ] Automated (unit/ui) tests
- [x] Manual tests