### PR TITLE
[Bug] iOS. Some devices are opening on the previous quarterly, even if they opened the new quarter previously

### DIFF
--- a/Sabbath School/Common/Configuration/Configuration.swift
+++ b/Sabbath School/Common/Configuration/Configuration.swift
@@ -137,7 +137,7 @@ class Configuration: NSObject {
         }
         
         if (PreferencesShared.loggedIn()) {
-            window?.rootViewController = QuarterlyWireFrame.createQuarterlyModule(initiateOpen: true)
+            window?.rootViewController = QuarterlyWireFrame.createQuarterlyModule(initiateOpen: false)
         } else {
             window?.rootViewController = LoginWireFrame.createLoginModule()
         }

--- a/Sabbath School/Lesson/Interactor/LessonInteractor.swift
+++ b/Sabbath School/Lesson/Interactor/LessonInteractor.swift
@@ -55,8 +55,4 @@ class LessonInteractor: LessonInteractorInputProtocol {
             try? self.storage?.setObject(quarterlyInfo, forKey: url)
         }
     }
-
-    func saveLastQuarterlyIndex(lastQuarterlyIndex: String) {
-        Preferences.userDefaults.set(lastQuarterlyIndex, forKey: Constants.DefaultKey.lastQuarterlyIndex)
-    }
 }

--- a/Sabbath School/Quarterly/Interactor/QuarterlyInteractor.swift
+++ b/Sabbath School/Quarterly/Interactor/QuarterlyInteractor.swift
@@ -65,6 +65,10 @@ class QuarterlyInteractor: QuarterlyInteractorInputProtocol {
         let language: QuarterlyLanguage = try! JSONDecoder().decode(QuarterlyLanguage.self, from: dictionary)
         retrieveQuarterliesForLanguage(language: language)
     }
+    
+    func saveLastQuarterlyIndex(lastQuarterlyIndex: String) {
+        Preferences.userDefaults.set(lastQuarterlyIndex, forKey: Constants.DefaultKey.lastQuarterlyIndex)
+    }
 }
 
 extension QuarterlyInteractor: LanguageInteractorOutputProtocol {

--- a/Sabbath School/Quarterly/Presenter/QuarterlyPresenter.swift
+++ b/Sabbath School/Quarterly/Presenter/QuarterlyPresenter.swift
@@ -49,6 +49,8 @@ class QuarterlyPresenter: QuarterlyPresenterProtocol {
     }
 
     func presentLessonScreen(quarterlyIndex: String, initiateOpenToday: Bool = false) {
+        
+        interactor?.saveLastQuarterlyIndex(lastQuarterlyIndex: quarterlyIndex)
         wireFrame?.presentLessonScreen(view: controller!, quarterlyIndex: quarterlyIndex, initiateOpenToday: initiateOpenToday)
     }
     

--- a/Sabbath School/Quarterly/Protocols/QuarterlyProtocols.swift
+++ b/Sabbath School/Quarterly/Protocols/QuarterlyProtocols.swift
@@ -64,4 +64,5 @@ protocol QuarterlyInteractorInputProtocol: AnyObject {
     func configure()
     func retrieveQuarterlies()
     func retrieveQuarterliesForLanguage(language: QuarterlyLanguage)
+    func saveLastQuarterlyIndex(lastQuarterlyIndex: String)
 }


### PR DESCRIPTION
# What did you change:

- Moving save quarterly to when user open it and disable open in quarter

# Merge checklist

- [ ] Automated (unit/ui) tests
- [x] Manual tests