### PR TITLE
[bug] App crashes if tap on multiple videos at the same time.

### DIFF
--- a/Sabbath School/Video/VideoPlayback.swift
+++ b/Sabbath School/Video/VideoPlayback.swift
@@ -118,6 +118,10 @@ class VideoPlaybackPlayerViewController: AVPlayerViewController {
 
 class VideoPlaybackDelegatable: ASDKViewController<ASDisplayNode> {
     func playVideo(video: Video, artwork: UIImage? = nil) {
+        if !VideoPlayback.shared.pip && presentedViewController != nil {
+            return
+        }
+
         let titleMetadata = AVMutableMetadataItem()
         titleMetadata.identifier = AVMetadataIdentifier.commonIdentifierTitle
         titleMetadata.value = video.title as NSString


### PR DESCRIPTION
# What did you change:

- Checking if is already presenting video player to prevent crashes 

# Merge checklist

- [ ] Automated (unit/ui) tests
- [x] Manual tests