### PR TITLE
Display "Sabbath" instead of Saturday in the header of the read screen

### DIFF
--- a/Sabbath School/Common/Configuration/Constants.swift
+++ b/Sabbath School/Common/Configuration/Constants.swift
@@ -121,4 +121,9 @@ struct Constants {
         static let featuredTodayWidget = "io.adventech.SabbathSchool.FeaturedTodayWidget"
         static let lessonInfoWidget = "io.adventech.SabbathSchool.LessonInfoWidget"
     }
+    
+    struct StringsToBeReplaced {
+        static let saturday = "Saturday"
+        static let sabbath = "Sabbath"
+    }
 }

--- a/Sabbath School/Read/View/ReadView.swift
+++ b/Sabbath School/Read/View/ReadView.swift
@@ -81,8 +81,9 @@ class ReadView: ASCellNode {
 
         date.alpha = 1
         date.maximumNumberOfLines = 1
-        date.attributedText = AppStyle.Read.Text.date(string: read.date.stringReadDate())
-        
+        let formattedDate = read.date.stringReadDate().replacingLastOccurrence(of: Constants.StringsToBeReplaced.saturday,
+                                                                               with: Constants.StringsToBeReplaced.sabbath)
+        date.attributedText = AppStyle.Read.Text.date(string: formattedDate)
         
         automaticallyManagesSubnodes = true
     }


### PR DESCRIPTION
# What did you change:

- Display "Sabbath" instead of Saturday in the header of the read screen

# Merge checklist

- [ ] Automated (unit/ui) tests
- [x] Manual tests