### PR TITLE
Add shadow effect to readings title and date

### DIFF
--- a/Sabbath School/Read/View/ReadView.swift
+++ b/Sabbath School/Read/View/ReadView.swift
@@ -46,8 +46,8 @@ class ReadView: ASCellNode {
     weak var delegate: ReadViewOutputProtocol?
     let cover = ASNetworkImageNode()
     let coverOverlay = ASDisplayNode()
-    let title = ASTextNode()
-    let date = ASTextNode()
+    let title = ASTextNode2()
+    let date = ASTextNode2()
 
     let webNode = ASDisplayNode { Reader() }
     var read: Read?
@@ -75,12 +75,16 @@ class ReadView: ASCellNode {
         coverOverlay.alpha = 0
 
         title.alpha = 1
-        title.maximumNumberOfLines = 2
-        title.pointSizeScaleFactors = [0.9, 0.8]
+        title.maximumNumberOfLines = 3
+        title.shadowOpacity = 0.8
+        title.shadowOffset = CGSize(width: 1, height: 2)
         title.attributedText = AppStyle.Read.Text.title(string: read.title)
 
         date.alpha = 1
         date.maximumNumberOfLines = 1
+        date.shadowOpacity = 0.8
+        date.shadowRadius = 1
+        date.shadowOffset = CGSize(width: 1, height: 1)
         let formattedDate = read.date.stringReadDate().replacingLastOccurrence(of: Constants.StringsToBeReplaced.saturday,
                                                                                with: Constants.StringsToBeReplaced.sabbath)
         date.attributedText = AppStyle.Read.Text.date(string: formattedDate)


### PR DESCRIPTION
Add shadow effect to readings title and date for better readability on bright images.

| Before | After |
|--------|------|
|![before1](https://user-images.githubusercontent.com/5223485/183066048-c6404e53-31ec-4cf1-b8d5-14a9e028ca2b.png)|![after1](https://user-images.githubusercontent.com/5223485/183066101-c5cece24-855b-4e08-99b8-002fc2798305.png)|
|![before2](https://user-images.githubusercontent.com/5223485/183066189-b9ffdb0e-bda2-452a-b80d-ac2872411f37.png)|![after2](https://user-images.githubusercontent.com/5223485/183066228-1591f209-baed-47c4-8827-d03ec39ecb52.png)|


