### PR TITLE
Fix PDF progress download

### DIFF
--- a/Sabbath School/Common/Library/Downloader.swift
+++ b/Sabbath School/Common/Library/Downloader.swift
@@ -57,6 +57,7 @@ extension Downloader: URLSessionDelegate, URLSessionDownloadDelegate {
         do {
             try FileManager().moveItem(at: location, to: destinationFileURL)
             moveProgress.completedUnitCount = moveProgress.totalUnitCount
+            progress.completedUnitCount = progress.totalUnitCount
             didFinishDownloading?(location)
         } catch {
             print(error)


### PR DESCRIPTION
Hey guys, I got a bug that occurs when the http server of the PDF doesn't provide the Content-Length, so the download progress is never finished, because the totalBytesExpectedToWrite always returns the value -1.

To fix this I added inside the method that is called when the download is finished to complete the progress.

**Behavior with the bug**

https://github.com/Adventech/sabbath-school-ios/assets/13000765/f14e5dcd-ad15-41f2-922a-d5be392838ae

**Behavior after solution**

https://github.com/Adventech/sabbath-school-ios/assets/13000765/044db2ed-7820-4d14-bdd6-153260a0df1f

