### PR TITLE
Fix toolbar item color

### DIFF
--- a/Sabbath School/View/Document/DocumentToolbarView.swift
+++ b/Sabbath School/View/Document/DocumentToolbarView.swift
@@ -37,9 +37,7 @@ extension DocumentView {
                         } label: {
                             Image(systemName: "headphones")
                                 .renderingMode(.original)
-                                .foregroundColor(documentViewOperator.shouldShowNavigationBar
-                                                 ? (colorScheme == .dark ? .white : .black)
-                                                 : (documentViewOperator.shouldShowCovers() ? .white : .black))
+                                .foregroundColor(resolvedForegroundColor())
                                 .aspectRatio(contentMode: .fit)
                                 .imageScale(.medium)
                         }
@@ -53,9 +51,7 @@ extension DocumentView {
                         } label: {
                             Image(systemName: "play.tv")
                                 .renderingMode(.original)
-                                .foregroundColor(documentViewOperator.shouldShowNavigationBar
-                                                 ? (colorScheme == .dark ? .white : .black)
-                                                 : (documentViewOperator.shouldShowCovers() ? .white : .black))
+                                .foregroundColor(resolvedForegroundColor())
                                 .aspectRatio(contentMode: .fit)
                                 .imageScale(.medium)
                         }
@@ -99,9 +95,7 @@ extension DocumentView {
                 } label : {
                     Image(systemName: "ellipsis")
                         .renderingMode(.original)
-                        .foregroundColor(documentViewOperator.shouldShowNavigationBar
-                                         ? (colorScheme == .dark ? .white : .black)
-                                         : (documentViewOperator.shouldShowCovers() ? .white : .black))
+                        .foregroundColor(resolvedForegroundColor())
                         .aspectRatio(contentMode: .fit)
                         .id(documentViewOperator.shouldShowNavigationBar)
                         .transition(.opacity.animation(.easeInOut))
@@ -111,4 +105,13 @@ extension DocumentView {
             }
         }
     }
+    
+    private func resolvedForegroundColor() -> Color {
+        documentViewOperator.shouldShowNavigationBar
+            ? themeManager.getTextColor()
+            : (documentViewOperator.shouldShowCovers()
+               ? themeManager.getSecondaryBackgroundColor()
+               : themeManager.getTextColor())
+    }
+
 }

--- a/Sabbath School/View/Document/DocumentView.swift
+++ b/Sabbath School/View/Document/DocumentView.swift
@@ -64,9 +64,10 @@ struct DocumentView: View {
                     : "arrow.backward")
             .symbolRenderingMode(documentViewOperator.shouldShowCovers() && !documentViewOperator.shouldShowNavigationBar ? .multicolor : .monochrome)
             .foregroundColor(documentViewOperator.shouldShowNavigationBar
-                             ? colorScheme == .dark ? .white : .black
-                             : (documentViewOperator.shouldShowCovers() ? .black.opacity(0.5) : colorScheme == .dark ? .white : .black)
-            )
+                             ? themeManager.getTextColor()
+                             : (documentViewOperator.shouldShowCovers()
+                                ? themeManager.getSecondaryTextColor().opacity(0.5)
+                                : themeManager.getTextColor()))
             .aspectRatio(contentMode: .fit)
             .id(documentViewOperator.shouldShowNavigationBar)
             .transition(.opacity.animation(.easeInOut))


### PR DESCRIPTION
Steps to reproduce:

- Put device in the Light Mode 
- Under `Devotional` tab, open first resource and click Read 
- Change Reading options to Dark
- Result is that the arrow back is black, which makes it invisible

<img width="845" alt="Screenshot 2025-03-12 at 10 35 48" src="https://github.com/user-attachments/assets/7c782490-d66d-44a3-b106-547998ba0141" />
