### PR TITLE
fix: preserve local input during remote merge

### DIFF
--- a/Sabbath School/Common/Model/AnyUserInput.swift
+++ b/Sabbath School/Common/Model/AnyUserInput.swift
@@ -51,6 +51,8 @@ enum UserInputType: String, Codable {
 }
 
 struct AnyUserInput: UserInputProtocol, Decodable, Hashable {
+    private static let millisecondTimestampThreshold: Int64 = 10_000_000_000
+
     private let _base: any UserInputProtocol
     
     var id: String = UUID().uuidString
@@ -65,6 +67,15 @@ struct AnyUserInput: UserInputProtocol, Decodable, Hashable {
     
     var timestamp: Int {
         return _base.timestamp
+    }
+
+    var timestampInMilliseconds: Int64 {
+        let timestamp = Int64(self.timestamp)
+        // Existing iOS records use epoch seconds while other clients use milliseconds.
+        if timestamp >= 0 && timestamp < Self.millisecondTimestampThreshold {
+            return timestamp * 1000
+        }
+        return timestamp
     }
     
     init(_ base: any UserInputProtocol) {

--- a/Sabbath School/Common/Model/LocalUserInput.swift
+++ b/Sabbath School/Common/Model/LocalUserInput.swift
@@ -36,4 +36,19 @@ struct LocalUserInput: Codable {
         self.synced = synced
         self.userInput = userInput
     }
+
+    func shouldBePreserved(over remoteUserInput: AnyUserInput) -> Bool {
+        guard userInput.blockId == remoteUserInput.blockId,
+              userInput.inputType == remoteUserInput.inputType else {
+            return false
+        }
+
+        // A dirty local row is the only unacknowledged copy and must survive a fetch.
+        if synced == false {
+            return true
+        }
+
+        // Equality cannot prove that a second-resolution remote response is newer.
+        return userInput.timestampInMilliseconds >= remoteUserInput.timestampInMilliseconds
+    }
 }

--- a/Sabbath School/View/Document/DocumentViewModel.swift
+++ b/Sabbath School/View/Document/DocumentViewModel.swift
@@ -210,7 +210,7 @@ class InlineAudioPlaybackManager: ObservableObject {
                 var mergedUserInput: [AnyUserInput] = []
                 
                 for userInput in remoteUserInput {
-                    if let localUserInput = localUserInputForDocument.first(where: { $0.userInput.blockId == userInput.blockId && $0.userInput.inputType == userInput.inputType && ($0.userInput.timestamp > userInput.timestamp) }) {
+                    if let localUserInput = localUserInputForDocument.first(where: { $0.shouldBePreserved(over: userInput) }) {
                         mergedUserInput.append(localUserInput.userInput)
                     } else {
                         let _ = SyncManager.shared.saveLocalInput(documentIndex: documentId, userInput: userInput, syncStatus: true)

--- a/Scripts/fixtures/legacy_local_input_seconds.json
+++ b/Scripts/fixtures/legacy_local_input_seconds.json
@@ -1,0 +1,10 @@
+{
+  "id": "synthetic-local-id",
+  "synced": false,
+  "userInput": {
+    "blockId": "synthetic-block",
+    "inputType": "comment",
+    "comment": "synthetic local edit",
+    "timestamp": 1735689600
+  }
+}

--- a/Scripts/validate_input_conflict_resolution.py
+++ b/Scripts/validate_input_conflict_resolution.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Regression checks for local/remote user-input conflict resolution."""
+
+import json
+from pathlib import Path
+import re
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+LOCAL_INPUT = ROOT / "Sabbath School/Common/Model/LocalUserInput.swift"
+ANY_INPUT = ROOT / "Sabbath School/Common/Model/AnyUserInput.swift"
+DOCUMENT_VIEW_MODEL = ROOT / "Sabbath School/View/Document/DocumentViewModel.swift"
+LEGACY_FIXTURE = ROOT / "Scripts/fixtures/legacy_local_input_seconds.json"
+
+
+def function_body(source, signature):
+    start = source.find(signature)
+    if start < 0:
+        return ""
+    opening = source.find("{", start)
+    if opening < 0:
+        return ""
+
+    depth = 0
+    for index in range(opening, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[opening + 1 : index]
+    return ""
+
+
+def ordered(body, *needles):
+    position = -1
+    for needle in needles:
+        position = body.find(needle, position + 1)
+        if position < 0:
+            return False
+    return True
+
+
+def expected_preserves(local, remote):
+    if (
+        local["userInput"]["blockId"] != remote["blockId"]
+        or local["userInput"]["inputType"] != remote["inputType"]
+    ):
+        return False
+    if local["synced"] is False:
+        return True
+    return normalized_milliseconds(local["userInput"]["timestamp"]) >= normalized_milliseconds(
+        remote["timestamp"]
+    )
+
+
+def normalized_milliseconds(timestamp):
+    return timestamp * 1000 if 0 <= timestamp < 10_000_000_000 else timestamp
+
+
+def behavior_matrix_passes(legacy_local):
+    remote = {
+        "blockId": "synthetic-block",
+        "inputType": "comment",
+        "comment": "synthetic stale remote",
+        "timestamp": legacy_local["userInput"]["timestamp"],
+    }
+
+    cases = [
+        (legacy_local, remote, True, "dirty same-second local"),
+        (
+            {
+                **legacy_local,
+                "userInput": {**legacy_local["userInput"], "timestamp": remote["timestamp"] - 30},
+            },
+            remote,
+            True,
+            "dirty clock-skewed local",
+        ),
+        ({**legacy_local, "synced": True}, remote, True, "acknowledged equal local"),
+        (
+            {
+                **legacy_local,
+                "synced": True,
+                "userInput": {**legacy_local["userInput"], "timestamp": remote["timestamp"] - 1},
+            },
+            remote,
+            False,
+            "acknowledged older local",
+        ),
+        (
+            {
+                **legacy_local,
+                "synced": True,
+                "userInput": {**legacy_local["userInput"], "timestamp": remote["timestamp"] + 1},
+            },
+            remote,
+            True,
+            "acknowledged newer local",
+        ),
+        (
+            {
+                **legacy_local,
+                "synced": True,
+                "userInput": {**legacy_local["userInput"], "timestamp": remote["timestamp"] + 1},
+            },
+            {**remote, "timestamp": remote["timestamp"] * 1000 + 500},
+            True,
+            "newer legacy-second local versus older millisecond remote",
+        ),
+        (
+            legacy_local,
+            {**remote, "blockId": "different-block"},
+            False,
+            "different identity",
+        ),
+    ]
+    return all(expected_preserves(local, candidate) is expected for local, candidate, expected, _ in cases)
+
+
+def reproduces_base_same_second_fallthrough(legacy_local):
+    remote = {
+        "blockId": legacy_local["userInput"]["blockId"],
+        "inputType": legacy_local["userInput"]["inputType"],
+        "comment": "synthetic stale remote",
+        "timestamp": legacy_local["userInput"]["timestamp"],
+    }
+    return (
+        legacy_local["synced"] is False
+        and legacy_local["userInput"]["comment"] != remote["comment"]
+        and legacy_local["userInput"]["timestamp"] == remote["timestamp"]
+        and not (legacy_local["userInput"]["timestamp"] > remote["timestamp"])
+    )
+
+
+def main():
+    local_source = LOCAL_INPUT.read_text(encoding="utf-8")
+    any_source = ANY_INPUT.read_text(encoding="utf-8")
+    view_model_source = DOCUMENT_VIEW_MODEL.read_text(encoding="utf-8")
+    legacy_local = json.loads(LEGACY_FIXTURE.read_text(encoding="utf-8"))
+
+    resolver_body = function_body(local_source, "func shouldBePreserved(")
+    coding_keys_body = function_body(any_source, "private enum CodingKeys")
+    retrieval_body = function_body(view_model_source, "func retrieveDocumentUserInput(")
+
+    checks = [
+        (
+            "LocalUserInput exposes one conflict policy for remote merges",
+            bool(
+                re.search(
+                    r"func\s+shouldBePreserved\s*\(over\s+remoteUserInput:\s*AnyUserInput\)\s*->\s*Bool",
+                    local_source,
+                )
+            ),
+        ),
+        (
+            "the policy matches both block and input type before comparing versions",
+            "userInput.blockId == remoteUserInput.blockId" in resolver_body
+            and "userInput.inputType == remoteUserInput.inputType" in resolver_body,
+        ),
+        (
+            "a dirty local row wins before wall-clock timestamps are considered",
+            ordered(
+                resolver_body,
+                "guard",
+                "if synced == false",
+                "return true",
+                "userInput.timestampInMilliseconds >= remoteUserInput.timestampInMilliseconds",
+            ),
+        ),
+        (
+            "an acknowledged local row wins a same-second tie but not an older comparison",
+            "return userInput.timestampInMilliseconds >= remoteUserInput.timestampInMilliseconds" in resolver_body,
+        ),
+        (
+            "legacy seconds and current milliseconds share a non-serialized comparison unit",
+            "var timestampInMilliseconds: Int64" in any_source
+            and "10_000_000_000" in any_source
+            and "timestamp >= 0" in any_source
+            and "timestamp * 1000" in any_source,
+        ),
+        (
+            "timestamp normalization does not add a wire or cache field",
+            "timestampInMilliseconds" not in coding_keys_body
+            and "try _base.encode(to: encoder)" in any_source,
+        ),
+        (
+            "the retrieval merge delegates matching and precedence to the policy",
+            "shouldBePreserved(over: userInput)" in retrieval_body,
+        ),
+        (
+            "the old inline strict-timestamp predicate is absent",
+            not re.search(
+                r"(?:\$0|localUserInput)\.userInput\.timestamp\s*>\s*userInput\.timestamp",
+                retrieval_body,
+            ),
+        ),
+        (
+            "preservation is decided before a remote row can replace local storage",
+            ordered(
+                retrieval_body,
+                "shouldBePreserved(over: userInput)",
+                "saveLocalInput(documentIndex: documentId, userInput: userInput, syncStatus: true)",
+            ),
+        ),
+        (
+            "legacy integer-second Codable input remains the wire/storage contract",
+            "struct LocalUserInput: Codable" in local_source
+            and "struct AnyUserInput: UserInputProtocol, Decodable" in any_source
+            and "var timestamp: Int { get }" in any_source
+            and isinstance(legacy_local["userInput"]["timestamp"], int)
+            and legacy_local["userInput"]["timestamp"] < 10_000_000_000
+            and normalized_milliseconds(legacy_local["userInput"]["timestamp"])
+            == 1_735_689_600_000,
+        ),
+        (
+            "the synthetic legacy fixture deterministically reaches the base equality fall-through",
+            reproduces_base_same_second_fallthrough(legacy_local),
+        ),
+        (
+            "deterministic same-second, clock-skew, acknowledged, and identity cases pass",
+            behavior_matrix_passes(legacy_local),
+        ),
+    ]
+
+    for description, passed in checks:
+        print("{}: {}".format("PASS" if passed else "FAIL", description))
+
+    if not all(passed for _, passed in checks):
+        print(
+            "\nConflict regression detected: a stale remote row can replace dirty local input.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("\nAll local/remote input conflict regression checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
# Draft PR packet: ADV-2026-0005

## Proposed PR

- Suggested title: `fix: preserve local input during remote merge`
- Upstream target: `Adventech/sabbath-school-ios` / `dev`
- Audited and last revalidated public base: `058426befc396279f3e8dca52b2a1bd8aad641eb`
- Published fork branch: `fix/adv-2026-0005-local-conflict`
- Published fork head: `773b8d368fc5b2d836693b3ba14f5321c9c03450`
- Local tree: `e0da0dbd8a2994e86fc9d5c3feaefa0ea8e6a05c`
- Shape: one commit, sole parent is the base above; one root only (`RC-0005`)
- State: published as draft PR [#196](https://github.com/Adventech/sabbath-school-ios/pull/196) from the authorized personal fork; not merged or deployed.

Publication privacy note: the branch commit metadata was recreated with the account's GitHub noreply identity. Its source tree, message, parent, and stable patch ID are unchanged.

## Why

iOS creates user-input timestamps at integer-second resolution, yet the remote merge preserves local data only when `local.timestamp > remote.timestamp`. A stale equal-second GET therefore replaces the local wrapper and marks it synced, deleting its only retryable copy. Android currently emits milliseconds, so unnormalized cross-client comparisons can also misorder records. This is a confirmed P0 contributor to iOS #176 and the annotation portion of lessons #4110.

## Failing-before reproduction

Seed a dirty local row and complete an older GET with the same block/type and integer second. The strict comparison is false; the base saves the stale remote row with `synced = true`, so the retry query no longer returns the local edit.

The committed validator replayed against base blobs exits 1 with eight expected contract failures, including no dirty-local precedence, no same-second local-first rule, no seconds/milliseconds normalization, and the old inline strict-timestamp predicate still present.

```powershell
python -I Scripts/validate_input_conflict_resolution.py
```

## Minimal fix

- Centralize matching and precedence in `LocalUserInput.shouldBePreserved(over:)`.
- Preserve every dirty local row before considering wall-clock values.
- For acknowledged rows, preserve local on normalized newer-or-equal timestamps; equality cannot prove remote freshness.
- Normalize legacy nonnegative epoch seconds to milliseconds only for comparison; do not serialize a new field or alter the original timestamp.
- Route `DocumentViewModel` merge decisions through that policy before any remote replacement.

No schema, project, package, content, localization, entitlement, workflow, deployment, or API file changes.

## Recorded local checks

- Expected RED on exact base blobs: validator exits 1 with 8 source-contract failures.
- PASS at head: `python -I Scripts/validate_input_conflict_resolution.py`, 12/12.
- PASS: Python syntax and synthetic legacy-seconds JSON fixture parsing.
- PASS: intended open-PR file intersections, diff check, one-commit distance, clean tree, and pairwise integration analysis.
- PASS in the refreshed verification-only iOS persistence stack: this validator remains 12/12; all six combined suites pass 71/71.
- PASS with RC-0007: automatic merge tree `ceb41dcbff380610a671f7a190b71eea4a894ff9` exactly matches integration commit `4dc08df9200057c769c39b7667578c9378a0c13f`; the two root validators pass 26/26.

These are Windows-hosted source/model checks. No Swift compilation, SwiftLint, XCTest, simulator, physical-device, hosted Actions, server, signing, store, or production result is claimed.

## Overlap and disposition

Current iOS PRs #190 (`11b5723be159c7f758e39f97be8eba81eb0634a2`), #192 (`bcf3970e63b122ece9a32a5b9c7dc5a2b07ea0be`), and #193's intended retargeted `dev`-relative delta have zero file overlap with this root. The connector's complete configured #193 file list contains 2,093 entries; the local rename-aware triple-dot comparison reports 2,060 changed paths after collapsing 33 rename pairs. That obsolete-`master` comparison technically intersects three ADV-0005 implementation paths, so it is not a zero-overlap proof. Preserve the matrix dispositions: supersede #190, split #192, and rebase/retarget #193.

RC-0005 and RC-0007 compose automatically: the direct merge-tree exits 0 at `ceb41dcbff380610a671f7a190b71eea4a894ff9`, exactly matching recorded integration commit `4dc08df9200057c769c39b7667578c9378a0c13f`, where both validators pass 26/26. No manual conflict resolution or rewritten publication head is required; retain one root per PR and rerun the combined runtime matrix on the release composition.

## Migration, recovery, and rollback

- No migration or stored-field change; existing Codable arrays and original timestamp values remain readable by older builds.
- This root cannot reconstruct local data already overwritten. Compare trusted local/server backups privately and never bulk-replace a newer value.
- It prevents client-side deletion but cannot settle genuine two-device conflicts without a server-issued monotonic revision or conditional token.
- A plain revert is format-compatible but restores destructive equal-timestamp behavior. Before rollback, prove every outbox row is durable/synced, preserve local cache bytes, and disable remote merge/offline editing if the fixed policy cannot remain.

## Security, privacy, and content rights

The fixture uses invented IDs/content. The fix adds no telemetry, logging, recipient, wire field, secret, credential, user data, translation, lesson, PDF/video asset, Bible/EGW material, or other rights-controlled content.

## Dependency order and draft blockers

RC-0007 remains a recommended earlier review because it establishes the durable-write boundary, but it does not require a conflict resolution or rewritten ADV-0005 head: the pair composes cleanly and passes 26/26 source/model checks. After publication from an authorized personal fork, keep the PR draft until locked packages build on macOS; SwiftLint/XCTest pass; same-second, mixed-unit, clock-skew, stale GET/POST, offline retry, process-death, rollback, and every user-input type pass; and an authorized nonproduction server proves revision, idempotency, and two-device conflict semantics. Re-run the combined persistence suite on the final composition.
