### PR TITLE
fix: preserve input when removing downloads

### DIFF
--- a/Sabbath School/Common/Configuration/Configuration.swift
+++ b/Sabbath School/Common/Configuration/Configuration.swift
@@ -77,7 +77,7 @@ class Configuration: NSObject {
         }
     }
     
-    static func clearAllCache() {
+    static func clearDownloadedContent() {
         UIApplication.shared.shortcutItems = []
         Spotlight.clearSpotlight()
         
@@ -89,6 +89,15 @@ class Configuration: NSObject {
         }
 
         DispatchQueue.main.async {
+            DownloadManager.clearInMemoryDownloads()
+            Downloader.removeAllDownloadedFiles()
+        }
+    }
+
+    static func clearAllCache() {
+        clearDownloadedContent()
+
+        DispatchQueue.main.async {
             ResourceInfoViewModel.clearAllCache()
             ResourceFeedViewModel.clearAllCache()
             AuthorFeedViewModel.clearAllCache()
@@ -96,8 +105,6 @@ class Configuration: NSObject {
             DocumentViewModel.clearAllCache()
             SyncManager.clearAllCache()
             DownloadManager.clearAllCache()
-            
-            Downloader.removeAllDownloadedFiles()
         }
     }
     

--- a/Sabbath School/Common/Configuration/DownloadManager.swift
+++ b/Sabbath School/Common/Configuration/DownloadManager.swift
@@ -394,10 +394,14 @@ class DownloadManager: ObservableObject {
         }
     }
     
+    public static func clearInMemoryDownloads() {
+        DownloadManager.shared.downloadItems = [:]
+        DownloadManager.shared.downloadKeys = []
+    }
+
     public static func clearAllCache() {
         try? DownloadManager.downloadManagerStorage?.removeAll()
         try? DownloadManager.downloadManagerKeys?.removeAll()
-        DownloadManager.shared.downloadItems = [:]
-        DownloadManager.shared.downloadKeys = []
+        clearInMemoryDownloads()
     }
 }

--- a/Sabbath School/View/Settings/SettingsView.swift
+++ b/Sabbath School/View/Settings/SettingsView.swift
@@ -109,7 +109,7 @@ struct SettingsView: View {
                             title: Text("Remove all downloads".localized()),
                             message: Text("By removing all downloads you will lose all the lessons content currently saved offline. Are you sure you want to proceed?".localized()),
                             primaryButton: .destructive(Text("Yes".localized())) {
-                                Configuration.clearAllCache()
+                                Configuration.clearDownloadedContent()
                             },
                             secondaryButton: .cancel()
                         )

--- a/Scripts/validate_remove_downloads_preserves_user_input.py
+++ b/Scripts/validate_remove_downloads_preserves_user_input.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Guard the remove-downloads action from shared user-input storage APIs."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+SETTINGS_FILE = REPOSITORY_ROOT / "Sabbath School" / "View" / "Settings" / "SettingsView.swift"
+CONFIGURATION_FILE = (
+    REPOSITORY_ROOT
+    / "Sabbath School"
+    / "Common"
+    / "Configuration"
+    / "Configuration.swift"
+)
+DOWNLOAD_MANAGER_FILE = (
+    REPOSITORY_ROOT
+    / "Sabbath School"
+    / "Common"
+    / "Configuration"
+    / "DownloadManager.swift"
+)
+SYNC_MANAGER_FILE = (
+    REPOSITORY_ROOT
+    / "Sabbath School"
+    / "Common"
+    / "Configuration"
+    / "SyncManager.swift"
+)
+
+SAFE_CONFIGURATION_METHOD = "clearDownloadedContent"
+SAFE_DOWNLOAD_MANAGER_METHOD = "clearInMemoryDownloads"
+
+
+def function_body(source: str, name: str) -> str | None:
+    declaration = re.search(
+        rf"\b(?:public\s+)?static\s+func\s+{re.escape(name)}\s*\([^)]*\)\s*\{{",
+        source,
+    )
+    if declaration is None:
+        return None
+
+    opening_brace = declaration.end() - 1
+    depth = 0
+    for index in range(opening_brace, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[opening_brace + 1 : index]
+    return None
+
+
+def main() -> int:
+    settings = SETTINGS_FILE.read_text(encoding="utf-8")
+    configuration = CONFIGURATION_FILE.read_text(encoding="utf-8")
+    download_manager = DOWNLOAD_MANAGER_FILE.read_text(encoding="utf-8")
+    sync_manager = SYNC_MANAGER_FILE.read_text(encoding="utf-8")
+    errors: list[str] = []
+
+    settings_configuration_calls = re.findall(
+        r"Configuration\.([A-Za-z][A-Za-z0-9_]*)\(\)", settings
+    )
+    expected_settings_calls = [SAFE_CONFIGURATION_METHOD]
+    if settings_configuration_calls != expected_settings_calls:
+        errors.append(
+            "the remove-downloads settings action must call only "
+            f"Configuration.{SAFE_CONFIGURATION_METHOD}(); found "
+            f"{settings_configuration_calls!r}"
+        )
+
+    broad_clear = function_body(configuration, "clearAllCache") or ""
+    sync_clear = function_body(sync_manager, "clearAllCache") or ""
+    if (
+        "clearAllCache" in settings_configuration_calls
+        and "SyncManager.clearAllCache()" in broad_clear
+        and "localInputStorage?.removeAll()" in sync_clear
+    ):
+        errors.append(
+            "unsafe path confirmed: Settings remove downloads -> "
+            "Configuration.clearAllCache -> SyncManager.clearAllCache -> "
+            "localInputStorage.removeAll"
+        )
+
+    safe_clear = function_body(configuration, SAFE_CONFIGURATION_METHOD)
+    if safe_clear is None:
+        errors.append(
+            f"Configuration.{SAFE_CONFIGURATION_METHOD}() is missing"
+        )
+    else:
+        for forbidden in ("APICache.", "SyncManager."):
+            if forbidden in safe_clear:
+                errors.append(
+                    f"Configuration.{SAFE_CONFIGURATION_METHOD}() reaches shared "
+                    f"storage through {forbidden}"
+                )
+
+        for forbidden in re.findall(
+            r"\b[A-Za-z][A-Za-z0-9_]*\.clearAllCache\(\)", safe_clear
+        ):
+            errors.append(
+                f"Configuration.{SAFE_CONFIGURATION_METHOD}() reaches shared "
+                f"storage through {forbidden}"
+            )
+
+        for required in (
+            "DownloadManager.clearInMemoryDownloads()",
+            "Downloader.removeAllDownloadedFiles()",
+        ):
+            if required not in safe_clear:
+                errors.append(
+                    f"Configuration.{SAFE_CONFIGURATION_METHOD}() must call {required}"
+                )
+
+    memory_clear = function_body(download_manager, SAFE_DOWNLOAD_MANAGER_METHOD)
+    if memory_clear is None:
+        errors.append(
+            f"DownloadManager.{SAFE_DOWNLOAD_MANAGER_METHOD}() is missing"
+        )
+    else:
+        for forbidden in (
+            "APICache.",
+            "downloadManagerStorage",
+            "downloadManagerKeys",
+            ".removeAll(",
+            ".removeObject(",
+            ".setObject(",
+        ):
+            if forbidden in memory_clear:
+                errors.append(
+                    f"DownloadManager.{SAFE_DOWNLOAD_MANAGER_METHOD}() must be "
+                    f"memory-only; found {forbidden}"
+                )
+
+        for required in ("downloadItems = [:]", "downloadKeys = []"):
+            if required not in memory_clear:
+                errors.append(
+                    f"DownloadManager.{SAFE_DOWNLOAD_MANAGER_METHOD}() must reset "
+                    f"{required}"
+                )
+
+    if errors:
+        print("Remove-downloads preservation validation failed:", file=sys.stderr)
+        for error in errors:
+            print(f" - {error}", file=sys.stderr)
+        return 1
+
+    print(
+        "Remove-downloads preservation validation passed: no shared user-input "
+        "storage mutation is reachable from the settings action."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
# Draft PR packet: ADV-2026-0006

## Proposed PR

- Suggested title: `fix: preserve input when removing downloads`
- Upstream target: `Adventech/sabbath-school-ios` / `dev`
- Audited and last revalidated public base: `058426befc396279f3e8dca52b2a1bd8aad641eb`
- Published fork branch: `fix/adv-2026-0006-content-clear-guard`
- Published fork head: `acf7c807631e9b93143e38886065869d1324dc1c`
- Local tree: `2854be55299842725e36741b5ec8ddb31e25519f`
- Shape: one commit, sole parent is the base above; one root only (`RC-0006`)
- State: published as draft PR [#197](https://github.com/Adventech/sabbath-school-ios/pull/197) from the authorized personal fork; not merged or deployed.

Publication privacy note: the branch commit metadata was recreated with the account's GitHub noreply identity. Its source tree, message, parent, and stable patch ID are unchanged.

## Why

The "Remove all downloads" settings action called the broad cache-clear path, which reaches `SyncManager.clearAllCache()` and `localInputStorage.removeAll()`. Because transformed Cache stores share the same underlying disk directory, deleting only the explicit sync call would still leave destructive routes through other shared cache clears. Unsynced, anonymous, offline, and failed-sync input can therefore be erased. This is a confirmed P0 loss path.

## Failing-before reproduction

```powershell
python -I Scripts/validate_remove_downloads_preserves_user_input.py
```

Before the fix, the source-contract validator exits 1 and reports the exact reachable chain `Settings -> Configuration.clearAllCache -> SyncManager.clearAllCache -> localInputStorage.removeAll`, plus the absence of a settings-safe content-only path.

## Minimal fix

- Route the settings confirmation to `Configuration.clearDownloadedContent()`.
- Clear transient URL/image/Nuke caches, physical downloaded files, and in-memory download bookkeeping only.
- Do not call `APICache`, `SyncManager`, broad model cache clears, or persistent `DownloadManager` storage from this action.
- Keep the pre-existing broad logout clear and its account-boundary semantics unchanged.

Only settings/configuration/download-manager source and the validator change. Durable store code and formats remain byte-identical.

## Recorded local checks

- Expected RED on exact base: four source-contract failures expose the destructive call chain and missing safe path.
- PASS: `python -I Scripts/validate_remove_downloads_preserves_user_input.py` after the fix.
- PASS: Python syntax, intended open-PR intersections, `0/1` branch distance, diff check, localization exclusion, and clean tree.
- PASS: base/head blob identity for `SyncManager.swift` and `APICache.swift`.
- PASS: broad-clear call-site searches; the broad configuration clear remains only at logout.
- PASS in verification-only compositions: all pairwise P0 merges are clean; prior stack plus this root exactly matches recorded `df3e48d` tree `271dc31d` at historical 41/41; refreshed P0/full heads pass 43/43 and 71/71.

These are Windows-hosted source checks. No Swift compilation, SwiftLint, XCTest, simulator, physical-device sandbox, active-download, hosted Actions, signing, store, or production result is claimed.

## Overlap and disposition

Current iOS PRs #190 (`11b5723be159c7f758e39f97be8eba81eb0634a2`), #192 (`bcf3970e63b122ece9a32a5b9c7dc5a2b07ea0be`), and #193's intended retargeted `dev`-relative delta have zero file overlap with this root. The connector's complete configured #193 file list contains 2,093 entries; the local rename-aware triple-dot comparison reports 2,060 changed paths after collapsing 33 rename pairs. That obsolete-`master` comparison technically intersects three ADV-0006 implementation paths, so it is not a zero-overlap proof. Preserve their existing supersede/split/rebase dispositions.

RC-0006 is independent of RC-0005/0007/0008 and remains one PR. The verification stack is evidence only, not a publication head.

## Migration, recovery, and rollback

- No schema or namespace migration is introduced; existing input remains readable.
- Persistent download metadata may remain stale because it shares the old namespace. That recoverable UX limitation and active-download recreation are separate content-cache follow-ups, not blockers to eliminating the private-input deletion route.
- This guard cannot restore input already deleted. Recover only from trusted private device/server backups after conflict checks.
- Reverting the commit restores the P0 deletion route. If download removal regresses, hide/disable the settings action while preserving the guard; never route it back to broad cache clear.

## Security, privacy, and content rights

The goal is byte-for-byte preservation of private input storage. No private payload, secret, credential, telemetry, translation, lesson, PDF/video asset, Bible/EGW material, signing, or deployment configuration changes.

## Dependency order and draft blockers

This emergency guard is independently reviewable. After publication from an authorized personal fork, keep the PR draft until the locked app builds on macOS and a simulator/device test quiesces sync, hashes the complete user-input store before and after remove-downloads, cold-relaunches offline, and verifies anonymous/authenticated/failed-sync/PDF input remains byte-identical while expected files are removed. Also test active downloads, background/termination, known stale metadata, and required hosted checks.
