### PR TITLE
fix: make local input writes recoverable

### DIFF
--- a/Sabbath School/Common/Configuration/SyncManager.swift
+++ b/Sabbath School/Common/Configuration/SyncManager.swift
@@ -24,7 +24,15 @@ import Cache
 import Foundation
 
 final class SyncManager {
+    private enum LocalInputPersistenceError: Error {
+        case storageUnavailable
+        case validationFailed
+    }
+
     private static var localInputStorage: Storage<String, [LocalUserInput]>?
+    private static let recoveryKeyPrefix = "__local_user_input_recovery_v1__:"
+
+    private let persistenceQueue = DispatchQueue(label: "org.adventech.sabbath-school.local-input-persistence")
     
     static let shared = SyncManager()
     
@@ -37,65 +45,146 @@ final class SyncManager {
     }
     
     func getLocalInput(documentIndex: String) -> [LocalUserInput] {
-        guard let cached = (try? SyncManager.localInputStorage?.entry(forKey: documentIndex))?.object else {
-            return []
+        return persistenceQueue.sync {
+            guard let storage = SyncManager.localInputStorage else {
+                return []
+            }
+
+            let recoveryKey = self.recoveryKey(for: documentIndex)
+
+            do {
+                if let recoveredInput = try self.promotePendingRecovery(
+                    for: documentIndex,
+                    recoveryKey: recoveryKey,
+                    using: storage
+                ) {
+                    return recoveredInput
+                }
+            } catch {
+                // If promotion cannot finish, keep serving the durable sidecar.
+                do {
+                    if let pendingInput = try self.readStoredInput(forKey: recoveryKey, from: storage) {
+                        return pendingInput
+                    }
+                } catch {
+                    // An incomplete sidecar must not hide a readable canonical value.
+                }
+            }
+
+            do {
+                return try self.readStoredInput(forKey: documentIndex, from: storage) ?? []
+            } catch {
+                return []
+            }
         }
-        
-        return cached
     }
     
     func markAsSynced(documentIndex: String, localUserInputUUID: String) {
-        if (try? SyncManager.localInputStorage?.existsObject(forKey: documentIndex)) != nil {
-            if let localUserInputCached = try? SyncManager.localInputStorage?.entry(forKey: documentIndex) {
-                var localUserInputsForDocument = localUserInputCached.object
-                
-                if let localUserInputIndex = localUserInputsForDocument.firstIndex(where: { $0.id == localUserInputUUID }) {
-                    localUserInputsForDocument[localUserInputIndex].synced = true
+        persistenceQueue.sync {
+            if (try? SyncManager.localInputStorage?.existsObject(forKey: documentIndex)) != nil {
+                if let localUserInputCached = try? SyncManager.localInputStorage?.entry(forKey: documentIndex) {
+                    var localUserInputsForDocument = localUserInputCached.object
                     
-                    try? SyncManager.localInputStorage?.setObject(localUserInputsForDocument, forKey: documentIndex)
+                    if let localUserInputIndex = localUserInputsForDocument.firstIndex(where: { $0.id == localUserInputUUID }) {
+                        localUserInputsForDocument[localUserInputIndex].synced = true
+
+                        try? SyncManager.localInputStorage?.setObject(localUserInputsForDocument, forKey: documentIndex)
+                    }
                 }
             }
         }
     }
     
     func getAllUnsyncedLocalInputs(documentId: String) -> [LocalUserInput] {
-        var unsyncedItems: [LocalUserInput] = []
-        
-        if (try? SyncManager.localInputStorage?.existsObject(forKey: documentId)) != nil {
-            if let localUserInputCached = try? SyncManager.localInputStorage?.entry(forKey: documentId) {
-                unsyncedItems = localUserInputCached.object.filter { $0.synced == false }
-            }
-        }
-        
-        return unsyncedItems
+        return getLocalInput(documentIndex: documentId).filter { $0.synced == false }
     }
     
-    func saveLocalInput(documentIndex: String, userInput: AnyUserInput, syncStatus: Bool = false) -> LocalUserInput? {
-        var localUserInput: [LocalUserInput]?
-        
-        if (try? SyncManager.localInputStorage?.existsObject(forKey: documentIndex)) != nil {
-            if let localUserInputCached = try? SyncManager.localInputStorage?.entry(forKey: documentIndex) {
-                localUserInput = localUserInputCached.object
-            } else {
-                localUserInput = []
+    func saveLocalInput(documentIndex: String, userInput: AnyUserInput, syncStatus: Bool = false) throws -> LocalUserInput {
+        return try persistenceQueue.sync {
+            guard let storage = SyncManager.localInputStorage else {
+                throw LocalInputPersistenceError.storageUnavailable
             }
-        } else {
-            localUserInput = []
-        }
-        
-        if var localUserInput = localUserInput {
+
+            let recoveryKey = self.recoveryKey(for: documentIndex)
+            let recoveredInputs = try self.promotePendingRecovery(
+                for: documentIndex,
+                recoveryKey: recoveryKey,
+                using: storage
+            )
+            var updatedInputs = recoveredInputs ?? (try self.readStoredInput(forKey: documentIndex, from: storage) ?? [])
             let localUserInputEntry = LocalUserInput(synced: syncStatus, userInput: userInput)
             
-            if let existing = localUserInput.firstIndex(where: { $0.userInput.blockId == userInput.blockId && $0.userInput.inputType == userInput.inputType }) {
-                localUserInput[existing] = localUserInputEntry
+            if let existing = updatedInputs.firstIndex(where: { $0.userInput.blockId == userInput.blockId && $0.userInput.inputType == userInput.inputType }) {
+                updatedInputs[existing] = localUserInputEntry
             } else {
-                localUserInput.append(localUserInputEntry)
+                updatedInputs.append(localUserInputEntry)
             }
-            
-            try? SyncManager.localInputStorage?.setObject(localUserInput, forKey: documentIndex)
+
+            // Keep a complete validated snapshot while Cache replaces canonical data in place.
+            try self.persistAndValidate(updatedInputs, forKey: recoveryKey, using: storage)
+            try self.persistAndValidate(updatedInputs, forKey: documentIndex, using: storage)
+            try storage.removeObject(forKey: recoveryKey)
+
             return localUserInputEntry
         }
-        return nil
+    }
+
+    private func recoveryKey(for documentIndex: String) -> String {
+        return SyncManager.recoveryKeyPrefix + documentIndex
+    }
+
+    private func readStoredInput(
+        forKey key: String,
+        from storage: Storage<String, [LocalUserInput]>
+    ) throws -> [LocalUserInput]? {
+        do {
+            return try storage.entry(forKey: key).object
+        } catch StorageError.notFound {
+            return nil
+        } catch let error as CocoaError where error.code == .fileReadNoSuchFile {
+            return nil
+        }
+    }
+
+    private func encodedInputs(_ inputs: [LocalUserInput]) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return try encoder.encode(inputs)
+    }
+
+    private func persistAndValidate(
+        _ inputs: [LocalUserInput],
+        forKey key: String,
+        using storage: Storage<String, [LocalUserInput]>
+    ) throws {
+        do {
+            try storage.setObject(inputs, forKey: key)
+        } catch {
+            let writeError = error
+            try storage.removeInMemoryObject(forKey: key)
+            throw writeError
+        }
+
+        // Cache writes memory first; evict it so validation must read disk.
+        try storage.removeInMemoryObject(forKey: key)
+        guard let storedInputs = try readStoredInput(forKey: key, from: storage),
+              try encodedInputs(storedInputs) == encodedInputs(inputs) else {
+            throw LocalInputPersistenceError.validationFailed
+        }
+    }
+
+    private func promotePendingRecovery(
+        for documentIndex: String,
+        recoveryKey: String,
+        using storage: Storage<String, [LocalUserInput]>
+    ) throws -> [LocalUserInput]? {
+        guard let pendingInputs = try readStoredInput(forKey: recoveryKey, from: storage) else {
+            return nil
+        }
+
+        try persistAndValidate(pendingInputs, forKey: documentIndex, using: storage)
+        try storage.removeObject(forKey: recoveryKey)
+        return pendingInputs
     }
     
     public static func clearAllCache() {

--- a/Sabbath School/View/Document/DocumentViewModel.swift
+++ b/Sabbath School/View/Document/DocumentViewModel.swift
@@ -213,7 +213,11 @@ class InlineAudioPlaybackManager: ObservableObject {
                     if let localUserInput = localUserInputForDocument.first(where: { $0.userInput.blockId == userInput.blockId && $0.userInput.inputType == userInput.inputType && ($0.userInput.timestamp > userInput.timestamp) }) {
                         mergedUserInput.append(localUserInput.userInput)
                     } else {
-                        let _ = SyncManager.shared.saveLocalInput(documentIndex: documentId, userInput: userInput, syncStatus: true)
+                        do {
+                            let _ = try SyncManager.shared.saveLocalInput(documentIndex: documentId, userInput: userInput, syncStatus: true)
+                        } catch let error {
+                            print("SSDEBUG", error)
+                        }
                         mergedUserInput.append(userInput)
                     }
                 }
@@ -256,7 +260,7 @@ class InlineAudioPlaybackManager: ObservableObject {
                 documentUserInput.append(userInput)
             }
             
-            let localUserInputUUID = SyncManager.shared.saveLocalInput(documentIndex: documentId, userInput: userInput)
+            let localUserInputUUID = try SyncManager.shared.saveLocalInput(documentIndex: documentId, userInput: userInput)
             
             let userInput = try JSONSerialization.jsonObject(with: JSONEncoder().encode(userInput), options: .allowFragments) as! [String: Any]
             
@@ -267,9 +271,7 @@ class InlineAudioPlaybackManager: ObservableObject {
                 encoding: JSONEncoding.default
             ).response { response in
                 if response.response?.statusCode == 200 {
-                    if let localUserInputUUID = localUserInputUUID {
-                        SyncManager.shared.markAsSynced(documentIndex: documentId, localUserInputUUID: localUserInputUUID.id)
-                    }
+                    SyncManager.shared.markAsSynced(documentIndex: documentId, localUserInputUUID: localUserInputUUID.id)
                 }
             }
         } catch let error {

--- a/Scripts/validate_sync_manager_durability.py
+++ b/Scripts/validate_sync_manager_durability.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+"""Regression checks for durable local user-input persistence.
+
+This script is intentionally runnable without Xcode so the storage contract can
+be checked in CI and on non-macOS audit hosts.  It verifies the safety-critical
+ordering in SyncManager and that callers do not upload an input after its local
+write has failed.
+"""
+
+from pathlib import Path
+from copy import deepcopy
+import re
+import sys
+from typing import Dict, List, Optional, Set
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SYNC_MANAGER = ROOT / "Sabbath School/Common/Configuration/SyncManager.swift"
+DOCUMENT_VIEW_MODEL = ROOT / "Sabbath School/View/Document/DocumentViewModel.swift"
+
+
+def function_body(source: str, signature: str) -> str:
+    """Return a Swift function body using balanced braces."""
+    start = source.find(signature)
+    if start < 0:
+        return ""
+    opening = source.find("{", start)
+    if opening < 0:
+        return ""
+
+    depth = 0
+    for index in range(opening, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[opening + 1 : index]
+    return ""
+
+
+def ordered(body: str, *needles: str) -> bool:
+    position = -1
+    for needle in needles:
+        position = body.find(needle, position + 1)
+        if position < 0:
+            return False
+    return True
+
+
+class InjectedDiskFault(Exception):
+    pass
+
+
+class FaultStorage:
+    """Minimal Cache-compatible model: set mutates memory before disk."""
+
+    def __init__(self, canonical: List[str]):
+        self.disk = {"document": deepcopy(canonical)}
+        self.memory: Dict[str, List[str]] = {}
+        self.fail_write: Set[str] = set()
+        self.drop_write: Set[str] = set()
+        self.fail_remove: Set[str] = set()
+
+    def set(self, key: str, value: List[str]) -> None:
+        self.memory[key] = deepcopy(value)
+        if key in self.fail_write:
+            raise InjectedDiskFault(f"write:{key}")
+        if key not in self.drop_write:
+            self.disk[key] = deepcopy(value)
+
+    def evict(self, key: str) -> None:
+        self.memory.pop(key, None)
+
+    def read(self, key: str) -> Optional[List[str]]:
+        if key in self.memory:
+            return deepcopy(self.memory[key])
+        if key not in self.disk:
+            return None
+        self.memory[key] = deepcopy(self.disk[key])
+        return deepcopy(self.disk[key])
+
+    def remove(self, key: str) -> None:
+        self.memory.pop(key, None)
+        if key in self.fail_remove:
+            raise InjectedDiskFault(f"remove:{key}")
+        self.disk.pop(key, None)
+
+
+def persist_and_validate(storage: FaultStorage, key: str, value: List[str]) -> None:
+    try:
+        storage.set(key, value)
+    except InjectedDiskFault:
+        storage.evict(key)
+        raise
+    storage.evict(key)
+    if storage.read(key) != value:
+        raise InjectedDiskFault(f"validation:{key}")
+
+
+def journaled_save(storage: FaultStorage, value: str) -> None:
+    recovery_key = "recovery:document"
+    pending = storage.read(recovery_key)
+    if pending is not None:
+        persist_and_validate(storage, "document", pending)
+        storage.remove(recovery_key)
+        current = pending
+    else:
+        current = storage.read("document") or []
+
+    updated = current + [value]
+    persist_and_validate(storage, recovery_key, updated)
+    persist_and_validate(storage, "document", updated)
+    storage.remove(recovery_key)
+
+
+def preferred_read(storage: FaultStorage) -> List[str]:
+    pending = storage.read("recovery:document")
+    if pending is not None:
+        try:
+            persist_and_validate(storage, "document", pending)
+            storage.remove("recovery:document")
+        except InjectedDiskFault:
+            pass
+        return pending
+    return storage.read("document") or []
+
+
+def fault_model_passes() -> bool:
+    # A recovery write failure leaves the canonical last-known-good value intact.
+    recovery_failure = FaultStorage(["old"])
+    recovery_failure.fail_write.add("recovery:document")
+    try:
+        journaled_save(recovery_failure, "new")
+        return False
+    except InjectedDiskFault:
+        if preferred_read(recovery_failure) != ["old"]:
+            return False
+
+    # A canonical write failure leaves a validated recovery value, which the
+    # next transaction promotes before it accepts another edit.
+    canonical_failure = FaultStorage(["old"])
+    canonical_failure.fail_write.add("document")
+    try:
+        journaled_save(canonical_failure, "new")
+        return False
+    except InjectedDiskFault:
+        if preferred_read(canonical_failure) != ["old", "new"]:
+            return False
+    canonical_failure.fail_write.clear()
+    if preferred_read(canonical_failure) != ["old", "new"]:
+        return False
+    if "recovery:document" in canonical_failure.disk:
+        return False
+    journaled_save(canonical_failure, "newer")
+    if preferred_read(canonical_failure) != ["old", "new", "newer"]:
+        return False
+
+    # Cache can report success after a dropped createFile write. Eviction makes
+    # the validation read hit disk and detect the stale canonical bytes.
+    silent_drop = FaultStorage(["old"])
+    silent_drop.drop_write.add("document")
+    try:
+        journaled_save(silent_drop, "new")
+        return False
+    except InjectedDiskFault:
+        if preferred_read(silent_drop) != ["old", "new"]:
+            return False
+
+    # Failed journal cleanup is recoverable: both durable copies contain the
+    # new value and the recovery copy remains preferred.
+    cleanup_failure = FaultStorage(["old"])
+    cleanup_failure.fail_remove.add("recovery:document")
+    try:
+        journaled_save(cleanup_failure, "new")
+        return False
+    except InjectedDiskFault:
+        return preferred_read(cleanup_failure) == ["old", "new"]
+
+
+def main() -> int:
+    sync_source = SYNC_MANAGER.read_text(encoding="utf-8")
+    view_model_source = DOCUMENT_VIEW_MODEL.read_text(encoding="utf-8")
+
+    read_body = function_body(sync_source, "func readStoredInput(")
+    get_body = function_body(sync_source, "func getLocalInput(")
+    get_unsynced_body = function_body(sync_source, "func getAllUnsyncedLocalInputs(")
+    mark_synced_body = function_body(sync_source, "func markAsSynced(")
+    save_body = function_body(sync_source, "func saveLocalInput(")
+    persist_body = function_body(sync_source, "func persistAndValidate(")
+    promotion_body = function_body(sync_source, "func promotePendingRecovery(")
+    user_save_body = function_body(view_model_source, "func saveBlockUserInput(")
+    retrieval_body = function_body(view_model_source, "func retrieveDocumentUserInput(")
+
+    checks = [
+        (
+            "saveLocalInput propagates persistence errors and cannot report optional success",
+            bool(
+                re.search(
+                    r"func\s+saveLocalInput\s*\([^)]*\)\s*throws\s*->\s*LocalUserInput\b",
+                    sync_source,
+                    re.DOTALL,
+                )
+            ),
+        ),
+        (
+            "saveLocalInput serializes read-modify-write transactions",
+            "persistenceQueue.sync" in save_body,
+        ),
+        (
+            "sync acknowledgements cannot interleave with a local save transaction",
+            "persistenceQueue.sync" in mark_synced_body,
+        ),
+        (
+            "reads prefer a pending recovery record before canonical data",
+            ordered(
+                get_body,
+                "recoveryKey(for: documentIndex)",
+                "promotePendingRecovery",
+                "readStoredInput(forKey: recoveryKey",
+                "readStoredInput(forKey: documentIndex",
+            ),
+        ),
+        (
+            "corrupt data is propagated instead of being mistaken for an empty document",
+            "catch StorageError.notFound" in read_body
+            and "fileReadNoSuchFile" in read_body
+            and "catch {" not in read_body,
+        ),
+        (
+            "unsynced retries include recoverable journal data",
+            "getLocalInput(documentIndex: documentId)" in get_unsynced_body,
+        ),
+        (
+            "saveLocalInput promotes an existing recovery record before staging a replacement",
+            ordered(
+                save_body,
+                "promotePendingRecovery",
+                "persistAndValidate(updatedInputs, forKey: recoveryKey, using: storage",
+            ),
+        ),
+        (
+            "saveLocalInput stages and validates recovery before canonical data, then removes recovery",
+            ordered(
+                save_body,
+                "persistAndValidate(updatedInputs, forKey: recoveryKey, using: storage",
+                "persistAndValidate(updatedInputs, forKey: documentIndex, using: storage",
+                "removeObject(forKey: recoveryKey)",
+            ),
+        ),
+        (
+            "writes are throwing (never try?) and are followed by memory eviction plus disk read-back",
+            "try?" not in persist_body
+            and ordered(
+                persist_body,
+                "try storage.setObject",
+                "try storage.removeInMemoryObject",
+                "try readStoredInput",
+                "encodedInputs",
+            ),
+        ),
+        (
+            "recovery promotion validates canonical storage before deleting the journal",
+            ordered(
+                promotion_body,
+                "try readStoredInput",
+                "try persistAndValidate(pendingInputs, forKey: documentIndex, using: storage",
+                "try storage.removeObject(forKey: recoveryKey)",
+            ),
+        ),
+        (
+            "the user-edit caller requires a successful local save before encoding or POSTing",
+            ordered(
+                user_save_body,
+                "try SyncManager.shared.saveLocalInput",
+                "JSONSerialization.jsonObject",
+                "API.auth.request",
+            ),
+        ),
+        (
+            "the remote-merge caller handles the throwing persistence API",
+            "try SyncManager.shared.saveLocalInput" in retrieval_body,
+        ),
+        (
+            "the old swallowed-write pattern is absent from saveLocalInput",
+            not re.search(r"try\?\s+.*setObject", save_body),
+        ),
+        (
+            "fault model preserves old or recovery data across write, validation, and cleanup faults",
+            fault_model_passes(),
+        ),
+    ]
+
+    failed = [description for description, passed in checks if not passed]
+    for description, passed in checks:
+        print(f"{'PASS' if passed else 'FAIL'}: {description}")
+
+    if failed:
+        print(
+            "\nDurability regression detected: the current implementation can acknowledge "
+            "a local input without proving it reached disk.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("\nAll local-input durability regression checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
# Draft PR packet: ADV-2026-0007

## Proposed PR

- Suggested title: `fix: make local input writes recoverable`
- Upstream target: `Adventech/sabbath-school-ios` / `dev`
- Audited and last revalidated public base: `058426befc396279f3e8dca52b2a1bd8aad641eb`
- Published fork branch: `fix/adv-2026-0007-atomic-local-input`
- Published fork head: `db3c9a6c8e479e87e18a6cb844735c408cd0a0d5`
- Exact tree: `540afb51a1e7576de4eb686b396ac38ec9908437`
- Shape: one commit, sole parent is the base above; one root only (`RC-0007`)
- State: published as draft PR [#198](https://github.com/Adventech/sabbath-school-ios/pull/198) from the authorized personal fork; not merged or deployed.

Publication privacy note: the branch commit metadata was recreated with the account's GitHub noreply identity. Its source tree, message, parent, and stable patch ID are unchanged.

## Why

`SyncManager.saveLocalInput` treated missing, failed, and corrupt reads as empty; discarded write errors with `try?`; returned success after failed persistence; and allowed the caller to POST anyway. Cache 6.2.0 mutates memory before disk and reads memory first, so a normal read-after-write can also falsely validate a failed disk write. Every iOS input subtype is exposed. This is a confirmed P0 contributor to iOS #176.

## Failing-before reproduction

```powershell
python -I Scripts/validate_sync_manager_durability.py
```

The validator/fault model replayed against base blobs exits 1 with 13 expected failures: swallowed errors, no serialized transaction, corrupt-as-empty handling, no recovery-first read, no disk revalidation, and callers continuing before durable success. The model injects recovery write failure, canonical write failure, silent stale disk bytes, cleanup failure, later recovery, and a second edit while recovery is pending.

## Minimal fix

- Stage the complete updated array under a versioned recovery key.
- Evict Cache memory and compare deterministic disk-decoded bytes after every write.
- Promote to the unchanged canonical key only after the recovery record validates; remove recovery only after canonical validation.
- Prefer/promote a valid pending recovery record on reads and before a later edit.
- Serialize reads, read-modify-write saves, and sync acknowledgements on a private queue.
- Make `saveLocalInput` throwing and nonoptional; require durable success before encoding or POSTing.
- Preserve the canonical key, `[LocalUserInput]` Codable shape, IDs, API, project, packages, and schemas.

## Recorded local checks

- Expected RED on exact base blobs: validator exits 1 with 13 contract failures.
- PASS at head: `python -I Scripts/validate_sync_manager_durability.py`, 14 checks including the fault model.
- PASS: Python syntax, all production call-site checks, diff check, one-commit distance, and clean tree.
- PASS in the refreshed verification-only persistence stack: validator remains 14/14 and all six suites pass 71/71.

These are Windows-hosted source/fault-model checks. No Swift compilation, SwiftLint, XCTest, Cache filesystem injection on iOS, simulator, physical-device, hosted Actions, signing, store, or production result is claimed.

## Overlap and disposition

Current iOS PRs #190 (`11b5723be159c7f758e39f97be8eba81eb0634a2`) and #192 (`bcf3970e63b122ece9a32a5b9c7dc5a2b07ea0be`) have zero file overlap with this root. PR #193 (`ee4d537c2550a56a09425646e573ffb3c4a5603d`) still targets obsolete `master`; the connector's complete configured file list contains 2,093 entries, while the local rename-aware triple-dot comparison reports 2,060 changed paths after collapsing 33 rename pairs. That comparison technically includes `SyncManager.swift` and `DocumentViewModel.swift`. Its intended retargeted `dev`-relative delta is only two `zh-Hant` localization files and has zero ADV-0007 overlap. Re-run overlap and merge-tree checks after #193 is actually retargeted.

RC-0007 is the storage foundation for RC-0005. Their `DocumentViewModel.swift` integration must retain this root's throwing save/error handling plus RC-0005's local-preservation predicate. RC-0008 and RC-0006 are file-disjoint.

## Migration, recovery, and rollback

- No eager migration or canonical-format change; a successful transaction leaves only the old canonical representation.
- The recovery record is authoritative after it validates and before canonical validation/cleanup. Corrupt canonical bytes are preserved rather than replaced as empty.
- Temporary storage cost is one additional complete document-input snapshot; allocation failure retains the prior canonical value and throws.
- Older builds ignore recovery keys. Downgrade is safe only after every recovery record is promoted, canonical data survives cold relaunch, and no recovery key remains. Never delete an unresolved sidecar to force rollback.
- If both copies are unreadable, preserve the sandbox and recover privately; do not clear the cache.

## Security, privacy, and content rights

The sidecar temporarily duplicates private input within the existing Cache storage boundary and adds no recipient or logging. Device validation must confirm data-protection/backup attributes. No secret, credential, user payload, translation, lesson, PDF/video asset, Bible/EGW material, signing, or deployment configuration changes.

## Dependency order and draft blockers

Land this root before final RC-0005 integration. After publication from an authorized personal fork, keep the PR draft until locked packages compile on macOS; SwiftLint/XCTest pass; injected real-storage tests cover thrown/silent failures and corrupt data; a request spy proves no POST after persistence failure; process kill at every journal boundary, disk-full/low-storage, background/concurrent sync, large annotation payloads, cold relaunch, upgrade/downgrade, rollback, and data-protection checks pass on supported devices; and required hosted checks are green.
