### PR TITLE
fix: preserve PDF annotations during restore

### DIFF
--- a/Sabbath School/View/Segment/PDFAuxiliary/PDFAuxiliaryView.swift
+++ b/Sabbath School/View/Segment/PDFAuxiliary/PDFAuxiliaryView.swift
@@ -30,12 +30,100 @@ enum PDFAxiliryViewType {
     case aux
 }
 
-struct PDFAuxiliaryViewRepresentable: UIViewControllerRepresentable, PDFAuxiliaryViewControllerDelegate {
+private enum PDFAnnotationRestoreError: Error {
+    case missingDocumentProvider
+    case invalidPageIndex
+    case duplicatePageIndex
+    case invalidAnnotationEncoding
+    case mismatchedPageIndex
+    case annotationRemovalFailed
+    case annotationAdditionFailed
+    case rollbackFailed
+}
+
+private final class PDFAnnotationRestoreState {
+    private var acceptedSnapshots: [String: UserInputAnnotation] = [:]
+    private var dirtyPDFIds: Set<String> = []
+
+    func markDirty(pdfId: String) {
+        dirtyPDFIds.insert(pdfId)
+    }
+
+    func recordLocalSnapshot(_ snapshot: UserInputAnnotation) {
+        acceptedSnapshots[snapshot.pdfId] = snapshot
+        dirtyPDFIds.remove(snapshot.pdfId)
+    }
+
+    func recordRestoredSnapshot(_ snapshot: UserInputAnnotation) {
+        acceptedSnapshots[snapshot.pdfId] = snapshot
+    }
+
+    func shouldRestore(_ snapshot: UserInputAnnotation) -> Bool {
+        guard !dirtyPDFIds.contains(snapshot.pdfId) else {
+            return false
+        }
+
+        guard let acceptedSnapshot = acceptedSnapshots[snapshot.pdfId] else {
+            return true
+        }
+
+        // Timestamps have one-second precision. An equal version with different
+        // content cannot be ordered safely, so keep the last-known-good snapshot.
+        return snapshot.timestamp > acceptedSnapshot.timestamp
+    }
+
+    func candidates(
+        from documentUserInput: [AnyUserInput],
+        matchingPDFIds: Set<String>
+    ) -> [UserInputAnnotation] {
+        var candidatesByPDFId: [String: UserInputAnnotation] = [:]
+        var ambiguousPDFIds: Set<String> = []
+
+        for userInput in documentUserInput where userInput.inputType == .annotation {
+            guard let candidate = userInput.asType(UserInputAnnotation.self),
+                  matchingPDFIds.contains(candidate.pdfId) else {
+                continue
+            }
+
+            guard let existingCandidate = candidatesByPDFId[candidate.pdfId] else {
+                candidatesByPDFId[candidate.pdfId] = candidate
+                continue
+            }
+
+            if candidate.timestamp > existingCandidate.timestamp {
+                candidatesByPDFId[candidate.pdfId] = candidate
+                ambiguousPDFIds.remove(candidate.pdfId)
+            } else if candidate.timestamp == existingCandidate.timestamp,
+                      !Self.hasSamePayload(candidate, existingCandidate) {
+                ambiguousPDFIds.insert(candidate.pdfId)
+            }
+        }
+
+        return candidatesByPDFId.values
+            .filter { !ambiguousPDFIds.contains($0.pdfId) && shouldRestore($0) }
+            .sorted { $0.pdfId < $1.pdfId }
+    }
+
+    private static func hasSamePayload(
+        _ lhs: UserInputAnnotation,
+        _ rhs: UserInputAnnotation
+    ) -> Bool {
+        guard lhs.pdfId == rhs.pdfId,
+              lhs.data.count == rhs.data.count else {
+            return false
+        }
+
+        return zip(lhs.data, rhs.data).allSatisfy { lhsPage, rhsPage in
+            lhsPage.pageIndex == rhsPage.pageIndex &&
+            lhsPage.annotations == rhsPage.annotations
+        }
+    }
+}
+
+struct PDFAuxiliaryViewRepresentable: UIViewControllerRepresentable {
     var pdfs: [PDFAux]
     var viewType: PDFAxiliryViewType = .aux
     var showNavigationBarButtons: Bool = true
-    
-    @State var tabbedPDFController: PDFAuxiliaryTabbedViewController? = nil
     
     @Binding var pdfTabbedViewController: PDFAuxiliaryTabbedViewController?
     
@@ -95,7 +183,7 @@ struct PDFAuxiliaryViewRepresentable: UIViewControllerRepresentable, PDFAuxiliar
         
         let pdfController = PDFAuxiliaryViewController(document: nil, configuration: pdfConfiguration)
         
-        pdfController.pdfAuxiliaryViewControllerDelegate = self
+        pdfController.pdfAuxiliaryViewControllerDelegate = context.coordinator
         pdfController.viewType = viewType
         pdfController.showNavigationBarButtons = showNavigationBarButtons
         
@@ -105,78 +193,19 @@ struct PDFAuxiliaryViewRepresentable: UIViewControllerRepresentable, PDFAuxiliar
 
         let tabbedPDFController = PDFAuxiliaryTabbedViewController(pdfViewController: pdfController)
         tabbedPDFController.documents = documents
+        context.coordinator.tabbedPDFController = tabbedPDFController
         
         DispatchQueue.main.async {
-            self.tabbedPDFController = tabbedPDFController
             self.pdfTabbedViewController = tabbedPDFController
-            self.loadUserInput(documentUserInput: viewModel.documentUserInput)            
+            context.coordinator.loadUserInput(documentUserInput: viewModel.documentUserInput)
         }
         
         return tabbedPDFController
     }
-    
-    func loadUserInput(documentUserInput: [AnyUserInput]) {
-        let userInput = documentUserInput.filter { $0.inputType == .annotation }
-        
-        if let documents = self.tabbedPDFController?.documents {
-            documents.forEach { document in
-                let allAnnotations = document.allAnnotations(of: .all)
-
-                for pageIndex in allAnnotations {
-                    document.remove(annotations: pageIndex.value, options: .none)
-                }
-            }
-        }
-        
-        userInput.forEach { userInput in
-            if let annotation = userInput.asType(UserInputAnnotation.self),
-               let pdfIndex = pdfs.firstIndex(where: { $0.id == annotation.pdfId }),
-               let document = self.tabbedPDFController?.documents[pdfIndex]
-            {
-                for pageAnnotations in annotation.data {
-
-                    guard let documentProvider = document.documentProviders.first else { continue }
-                    var annotations: [Annotation] = []
-
-                    for annotation in pageAnnotations.annotations {
-                        do {
-                            let annotation = try Annotation(fromInstantJSON: annotation.data(using: .utf8)!, documentProvider: documentProvider)
-                            annotations.append(annotation)
-                        } catch let error as NSError {
-                            print(error)
-                        }
-
-                    }
-                    document.add(annotations: annotations)
-                }
-            }
-        }
-    }
-    
-    func saveUserInput(for documentToBeSaved: Document) {
-        if let documents = self.tabbedPDFController?.documents {
-            for (index, document) in documents.enumerated() {
-                guard documentToBeSaved == document else { continue }
-                
-                let inkAnnotations = document.allAnnotations(of: .all)
-                
-                var allAnnotations: [PDFAuxAnnotations] = []
-                for pageIndex in inkAnnotations {
-                    var annotations: [String] = []
-                    for annotation in pageIndex.value {
-                        let data = try! annotation.generateInstantJSON(version: .v1)
-                        let jsonString = String(data: data, encoding: .utf8)
-                        annotations.append(jsonString!)
-                    }
-                    allAnnotations.append(PDFAuxAnnotations(pageIndex: Int(pageIndex.key.intValue), annotations: annotations))
-                }
-                
-                self.viewModel.saveBlockUserInput(documentId: self.viewModel.document?.id, blockId: self.pdfs[index].id, userInputType: .annotation, userInput: AnyUserInput(UserInputAnnotation(pdfId: self.pdfs[index].id, data: allAnnotations, inputType: .annotation, blockId: self.pdfs[index].id, timestamp: Int(Date().timeIntervalSince1970))))
-            }
-        }
-    }
 
     func updateUIViewController(_ uiViewController: PDFAuxiliaryTabbedViewController, context: Context) {
+        context.coordinator.parent = self
+        context.coordinator.tabbedPDFController = uiViewController
         uiViewController.tabbedBar.frame.origin = CGPoint(x: 0, y: self.viewType == .aux ? 0 : 90)
     }
     
@@ -184,21 +213,292 @@ struct PDFAuxiliaryViewRepresentable: UIViewControllerRepresentable, PDFAuxiliar
         Coordinator(self, viewModel: viewModel)
     }
     
-    class Coordinator: NSObject, PDFViewControllerDelegate {
+    class Coordinator: NSObject, PDFViewControllerDelegate, PDFAuxiliaryViewControllerDelegate {
         var parent: PDFAuxiliaryViewRepresentable
-        var viewModel: DocumentViewModel
+        weak var tabbedPDFController: PDFAuxiliaryTabbedViewController?
+
+        private let viewModel: DocumentViewModel
+        private let restoreState = PDFAnnotationRestoreState()
         private var cancellable: AnyCancellable?
+        private var annotationObservers: [NSObjectProtocol] = []
+        private var isApplyingRestore = false
         
         init(_ parent: PDFAuxiliaryViewRepresentable, viewModel: DocumentViewModel) {
             self.parent = parent
             self.viewModel = viewModel
             super.init()
             
-            DispatchQueue.main.async { [self] in
-                cancellable = viewModel.$documentUserInput.sink { newValue in
-                    self.parent.loadUserInput(documentUserInput: newValue)
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+
+                self.cancellable = viewModel.$documentUserInput.sink { [weak self] newValue in
+                    self?.loadUserInput(documentUserInput: newValue)
+                }
+                self.startObservingAnnotationChanges()
+            }
+        }
+
+        func loadUserInput(documentUserInput: [AnyUserInput]) {
+            let candidates = restoreState.candidates(
+                from: documentUserInput,
+                matchingPDFIds: Set(parent.pdfs.map(\.id))
+            )
+
+            for candidate in candidates {
+                guard let target = restoreTarget(for: candidate.pdfId) else {
+                    continue
+                }
+
+                do {
+                    let replacement = try stageReplacement(for: candidate, in: target.document)
+                    try replaceAnnotations(in: target.document, with: replacement)
+                    restoreState.recordRestoredSnapshot(candidate)
+                } catch {
+                    // Keep the displayed and last-known-good annotations intact.
+                    print("Ignoring invalid PDF annotation snapshot for \(candidate.pdfId): \(error)")
                 }
             }
+        }
+
+        private func restoreTarget(for pdfId: String) -> (document: Document, index: Int)? {
+            guard let documents = tabbedPDFController?.documents else {
+                return nil
+            }
+
+            let matchingIndices = parent.pdfs.indices.filter { parent.pdfs[$0].id == pdfId }
+            guard matchingIndices.count == 1,
+                  let index = matchingIndices.first,
+                  documents.indices.contains(index) else {
+                return nil
+            }
+
+            return (documents[index], index)
+        }
+
+        private func stageReplacement(
+            for snapshot: UserInputAnnotation,
+            in document: Document
+        ) throws -> [Annotation] {
+            guard let documentProvider = document.documentProviders.first else {
+                throw PDFAnnotationRestoreError.missingDocumentProvider
+            }
+
+            var replacement: [Annotation] = []
+            var seenPageIndices: Set<Int> = []
+            let pageCount = Int(document.pageCount)
+
+            for pageSnapshot in snapshot.data {
+                guard pageSnapshot.pageIndex >= 0,
+                      pageCount == 0 || pageSnapshot.pageIndex < pageCount else {
+                    throw PDFAnnotationRestoreError.invalidPageIndex
+                }
+                guard seenPageIndices.insert(pageSnapshot.pageIndex).inserted else {
+                    throw PDFAnnotationRestoreError.duplicatePageIndex
+                }
+
+                for serializedAnnotation in pageSnapshot.annotations {
+                    guard let annotationData = serializedAnnotation.data(using: .utf8) else {
+                        throw PDFAnnotationRestoreError.invalidAnnotationEncoding
+                    }
+
+                    let decodedAnnotation = try Annotation(
+                        fromInstantJSON: annotationData,
+                        documentProvider: documentProvider
+                    )
+                    guard Int(decodedAnnotation.pageIndex) == pageSnapshot.pageIndex else {
+                        throw PDFAnnotationRestoreError.mismatchedPageIndex
+                    }
+
+                    replacement.append(decodedAnnotation)
+                }
+            }
+
+            return replacement
+        }
+
+        private func replaceAnnotations(
+            in document: Document,
+            with replacement: [Annotation]
+        ) throws {
+            // Instant JSON parsing above is deliberately side-effect free. Keep the
+            // remove/add window as small as the SDK permits and suppress our dirty guard.
+            isApplyingRestore = true
+            defer { isApplyingRestore = false }
+
+            let currentAnnotations = document.allAnnotations(of: .all).values.flatMap { $0 }
+            if !currentAnnotations.isEmpty {
+                guard document.remove(annotations: currentAnnotations, options: .none) else {
+                    guard restoreOriginalAnnotations(currentAnnotations, in: document) else {
+                        throw PDFAnnotationRestoreError.rollbackFailed
+                    }
+                    throw PDFAnnotationRestoreError.annotationRemovalFailed
+                }
+            }
+            if !replacement.isEmpty {
+                guard document.add(annotations: replacement, options: nil) else {
+                    let removedPartialReplacement = removeAttachedAnnotations(
+                        from: replacement,
+                        in: document
+                    )
+                    let restoredOriginal = restoreOriginalAnnotations(
+                        currentAnnotations,
+                        in: document
+                    )
+                    guard removedPartialReplacement, restoredOriginal else {
+                        throw PDFAnnotationRestoreError.rollbackFailed
+                    }
+                    throw PDFAnnotationRestoreError.annotationAdditionFailed
+                }
+            }
+        }
+
+        private func restoreOriginalAnnotations(
+            _ originalAnnotations: [Annotation],
+            in document: Document
+        ) -> Bool {
+            let attachedAnnotationIds = Set(
+                document.allAnnotations(of: .all).values
+                    .flatMap { $0 }
+                    .map { ObjectIdentifier($0) }
+            )
+            let missingAnnotations = originalAnnotations.filter {
+                !attachedAnnotationIds.contains(ObjectIdentifier($0))
+            }
+
+            return missingAnnotations.isEmpty ||
+                document.add(annotations: missingAnnotations, options: nil)
+        }
+
+        private func removeAttachedAnnotations(
+            from candidateAnnotations: [Annotation],
+            in document: Document
+        ) -> Bool {
+            let candidateIds = Set(candidateAnnotations.map { ObjectIdentifier($0) })
+            let attachedCandidates = document.allAnnotations(of: .all).values
+                .flatMap { $0 }
+                .filter { candidateIds.contains(ObjectIdentifier($0)) }
+
+            return attachedCandidates.isEmpty ||
+                document.remove(annotations: attachedCandidates, options: .none)
+        }
+
+        func saveUserInput(for documentToBeSaved: Document) {
+            guard let documentId = viewModel.document?.id,
+                  let documents = tabbedPDFController?.documents,
+                  let index = documents.firstIndex(where: { $0 == documentToBeSaved }),
+                  parent.pdfs.indices.contains(index),
+                  let snapshot = makeUserInputSnapshot(
+                    for: documentToBeSaved,
+                    pdfId: parent.pdfs[index].id
+                  ) else {
+                return
+            }
+
+            // Record the exact in-memory snapshot before @Published emits it back to
+            // this coordinator, avoiding a destructive self-restore during autosave.
+            restoreState.recordLocalSnapshot(snapshot)
+            viewModel.saveBlockUserInput(
+                documentId: documentId,
+                blockId: snapshot.blockId,
+                userInputType: .annotation,
+                userInput: AnyUserInput(snapshot)
+            )
+        }
+
+        private func makeUserInputSnapshot(
+            for document: Document,
+            pdfId: String
+        ) -> UserInputAnnotation? {
+            let annotationsByPage = document.allAnnotations(of: .all)
+            var pageSnapshots: [PDFAuxAnnotations] = []
+
+            for pageIndex in annotationsByPage.keys.sorted(by: { $0.intValue < $1.intValue }) {
+                guard let annotations = annotationsByPage[pageIndex] else {
+                    continue
+                }
+
+                var serializedAnnotations: [String] = []
+                for annotation in annotations {
+                    do {
+                        let data = try annotation.generateInstantJSON(version: .v1)
+                        guard let serializedAnnotation = String(data: data, encoding: .utf8) else {
+                            print("Unable to encode PDF annotation snapshot for \(pdfId)")
+                            return nil
+                        }
+                        serializedAnnotations.append(serializedAnnotation)
+                    } catch {
+                        print("Unable to serialize PDF annotation snapshot for \(pdfId): \(error)")
+                        return nil
+                    }
+                }
+
+                pageSnapshots.append(PDFAuxAnnotations(
+                    pageIndex: Int(pageIndex.intValue),
+                    annotations: serializedAnnotations
+                ))
+            }
+
+            return UserInputAnnotation(
+                pdfId: pdfId,
+                data: pageSnapshots,
+                inputType: .annotation,
+                blockId: pdfId,
+                timestamp: Int(Date().timeIntervalSince1970)
+            )
+        }
+
+        private func startObservingAnnotationChanges() {
+            guard annotationObservers.isEmpty else { return }
+
+            let names: [NSNotification.Name] = [
+                .PSPDFAnnotationsAdded,
+                .PSPDFAnnotationsRemoved,
+                .PSPDFAnnotationChanged
+            ]
+            annotationObservers = names.map { name in
+                NotificationCenter.default.addObserver(
+                    forName: name,
+                    object: nil,
+                    queue: .main
+                ) { [weak self] notification in
+                    self?.annotationDidChange(notification)
+                }
+            }
+        }
+
+        private func annotationDidChange(_ notification: Notification) {
+            guard !isApplyingRestore else { return }
+
+            let annotations: [Annotation]
+            if let changedAnnotation = notification.object as? Annotation {
+                annotations = [changedAnnotation]
+            } else if let changedAnnotations = notification.object as? NSArray {
+                annotations = changedAnnotations.compactMap { $0 as? Annotation }
+            } else {
+                return
+            }
+
+            for annotation in annotations {
+                if let pdfId = pdfId(for: annotation) {
+                    restoreState.markDirty(pdfId: pdfId)
+                }
+            }
+        }
+
+        private func pdfId(for annotation: Annotation) -> String? {
+            guard let documents = tabbedPDFController?.documents else {
+                return nil
+            }
+            let documentProvider = annotation.documentProvider
+
+            for (index, document) in documents.enumerated()
+                where parent.pdfs.indices.contains(index) {
+                if document.documentProviders.contains(where: { $0 === documentProvider }) {
+                    return parent.pdfs[index].id
+                }
+            }
+
+            return nil
         }
         
         func pdfViewController(_ pdfController: PDFViewController, didFinishRenderTaskFor: PDFPageView) {
@@ -226,13 +526,14 @@ struct PDFAuxiliaryViewRepresentable: UIViewControllerRepresentable, PDFAuxiliar
         }
         
         func fixTabBar () {
-            if let t = parent.tabbedPDFController {
+            if let t = tabbedPDFController {
                 t.tabbedBar.frame.origin = CGPoint(x: 0, y: parent.viewType == .segment ? parent.getNavbarMaxY() : 0)
             }
         }
         
         deinit {
             cancellable?.cancel()
+            annotationObservers.forEach { NotificationCenter.default.removeObserver($0) }
         }
     }
 }

--- a/Sabbath School/View/Segment/PDFAuxiliary/PDFAuxiliaryView.swift
+++ b/Sabbath School/View/Segment/PDFAuxiliary/PDFAuxiliaryView.swift
@@ -81,6 +81,7 @@ private final class PDFAnnotationRestoreState {
 
         for userInput in documentUserInput where userInput.inputType == .annotation {
             guard let candidate = userInput.asType(UserInputAnnotation.self),
+                  candidate.blockId == candidate.pdfId,
                   matchingPDFIds.contains(candidate.pdfId) else {
                 continue
             }

--- a/Sabbath School/View/Segment/PDFAuxiliary/PDFAuxiliaryViewController.swift
+++ b/Sabbath School/View/Segment/PDFAuxiliary/PDFAuxiliaryViewController.swift
@@ -22,12 +22,12 @@
 
 import PSPDFKitUI
 
-protocol PDFAuxiliaryViewControllerDelegate {
+protocol PDFAuxiliaryViewControllerDelegate: AnyObject {
     func saveUserInput(for document: Document)
 }
 
 class PDFAuxiliaryViewController: PDFViewController {
-    var pdfAuxiliaryViewControllerDelegate: PDFAuxiliaryViewControllerDelegate?
+    weak var pdfAuxiliaryViewControllerDelegate: PDFAuxiliaryViewControllerDelegate?
     var viewType: PDFAxiliryViewType = .aux
     var showNavigationBarButtons: Bool = false
     

--- a/Scripts/validate_pdf_annotation_restore.py
+++ b/Scripts/validate_pdf_annotation_restore.py
@@ -74,7 +74,11 @@ class RestoreModel:
         ambiguous: set[str] = set()
 
         for value in inputs:
-            if not isinstance(value, Snapshot) or value.pdf_id not in self.documents:
+            if (
+                not isinstance(value, Snapshot)
+                or value.block_id != value.pdf_id
+                or value.pdf_id not in self.documents
+            ):
                 continue
 
             existing = candidates.get(value.pdf_id)

--- a/Scripts/validate_pdf_annotation_restore.py
+++ b/Scripts/validate_pdf_annotation_restore.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Regression checks for document-scoped PDF annotation restoration.
+
+This repository has no XCTest target and the audit host does not provide Xcode.
+The tests below therefore exercise an executable model of the restore contract and
+also pin the safety-critical structure of the production Swift implementation.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import os
+import pathlib
+import subprocess
+import unittest
+from typing import Iterable
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SOURCE_PATH = ROOT / "Sabbath School/View/Segment/PDFAuxiliary/PDFAuxiliaryView.swift"
+CONTROLLER_SOURCE_PATH = (
+    ROOT / "Sabbath School/View/Segment/PDFAuxiliary/PDFAuxiliaryViewController.swift"
+)
+
+
+def load_production_source(path: pathlib.Path) -> str:
+    """Load the working tree, or a Git ref supplied for regression replay."""
+
+    source_ref = os.environ.get("PDF_ANNOTATION_RESTORE_SOURCE_REF")
+    if source_ref:
+        relative_path = path.relative_to(ROOT).as_posix()
+        return subprocess.check_output(
+            ["git", "show", f"{source_ref}:{relative_path}"],
+            cwd=ROOT,
+            text=True,
+            encoding="utf-8",
+        )
+    return path.read_text(encoding="utf-8")
+
+
+@dataclasses.dataclass(frozen=True)
+class PageSnapshot:
+    page_index: int
+    annotations: tuple[str, ...]
+
+
+@dataclasses.dataclass(frozen=True)
+class Snapshot:
+    pdf_id: str
+    timestamp: int
+    pages: tuple[PageSnapshot, ...]
+
+
+class RestoreModel:
+    """Small executable specification mirrored by the Swift coordinator."""
+
+    def __init__(self, documents: dict[str, list[dict[str, object]]]) -> None:
+        self.documents = documents
+        self.accepted: dict[str, Snapshot] = {}
+        self.dirty: set[str] = set()
+
+    def mark_dirty(self, pdf_id: str) -> None:
+        if pdf_id in self.documents:
+            self.dirty.add(pdf_id)
+
+    def record_local(self, snapshot: Snapshot) -> None:
+        self.accepted[snapshot.pdf_id] = snapshot
+        self.dirty.discard(snapshot.pdf_id)
+
+    def restore(self, inputs: Iterable[object]) -> None:
+        candidates: dict[str, Snapshot] = {}
+        ambiguous: set[str] = set()
+
+        for value in inputs:
+            if not isinstance(value, Snapshot) or value.pdf_id not in self.documents:
+                continue
+
+            existing = candidates.get(value.pdf_id)
+            if existing is None or value.timestamp > existing.timestamp:
+                candidates[value.pdf_id] = value
+                ambiguous.discard(value.pdf_id)
+            elif value.timestamp == existing.timestamp and value.pages != existing.pages:
+                ambiguous.add(value.pdf_id)
+
+        for pdf_id, candidate in candidates.items():
+            if pdf_id in ambiguous or pdf_id in self.dirty:
+                continue
+
+            accepted = self.accepted.get(pdf_id)
+            if accepted is not None:
+                if candidate.timestamp < accepted.timestamp:
+                    continue
+                if candidate.timestamp == accepted.timestamp:
+                    # Equal versions are either an echo or an unorderable conflict.
+                    continue
+
+            try:
+                replacement = self._stage(candidate)
+            except (TypeError, ValueError, json.JSONDecodeError):
+                continue
+
+            # The swap happens only after every annotation in this PDF validates.
+            self.documents[pdf_id] = replacement
+            self.accepted[pdf_id] = candidate
+
+    @staticmethod
+    def _stage(snapshot: Snapshot) -> list[dict[str, object]]:
+        replacement: list[dict[str, object]] = []
+        seen_pages: set[int] = set()
+
+        for page in snapshot.pages:
+            if page.page_index < 0 or page.page_index >= 100:
+                raise ValueError("page outside document")
+            if page.page_index in seen_pages:
+                raise ValueError("duplicate page")
+            seen_pages.add(page.page_index)
+
+            for serialized in page.annotations:
+                decoded = json.loads(serialized)
+                if not isinstance(decoded, dict):
+                    raise TypeError("annotation must be an object")
+                if decoded.get("pageIndex") != page.page_index:
+                    raise ValueError("annotation belongs to another page")
+                replacement.append(decoded)
+
+        return replacement
+
+
+def annotation(annotation_id: str, page_index: int = 0) -> str:
+    return json.dumps({"id": annotation_id, "pageIndex": page_index}, sort_keys=True)
+
+
+def snapshot(pdf_id: str, timestamp: int, *annotation_ids: str) -> Snapshot:
+    return Snapshot(
+        pdf_id=pdf_id,
+        timestamp=timestamp,
+        pages=(PageSnapshot(0, tuple(annotation(value) for value in annotation_ids)),),
+    )
+
+
+class RestoreContractTests(unittest.TestCase):
+    def test_unrelated_emissions_do_not_clear_any_pdf(self) -> None:
+        model = RestoreModel({"pdf-a": [{"id": "a"}], "pdf-b": [{"id": "b"}]})
+
+        model.restore([{"type": "comment"}, snapshot("pdf-c", 2, "c")])
+
+        self.assertEqual(model.documents["pdf-a"], [{"id": "a"}])
+        self.assertEqual(model.documents["pdf-b"], [{"id": "b"}])
+
+    def test_matching_update_swaps_only_its_document(self) -> None:
+        model = RestoreModel({"pdf-a": [{"id": "old-a"}], "pdf-b": [{"id": "old-b"}]})
+
+        model.restore([snapshot("pdf-a", 2, "new-a")])
+
+        self.assertEqual(model.documents["pdf-a"], [{"id": "new-a", "pageIndex": 0}])
+        self.assertEqual(model.documents["pdf-b"], [{"id": "old-b"}])
+
+    def test_malformed_snapshot_preserves_last_known_good(self) -> None:
+        model = RestoreModel({"pdf-a": [{"id": "visible"}]})
+        malformed = Snapshot("pdf-a", 3, (PageSnapshot(0, ("not-json",)),))
+
+        model.restore([malformed])
+
+        self.assertEqual(model.documents["pdf-a"], [{"id": "visible"}])
+        self.assertNotIn("pdf-a", model.accepted)
+
+    def test_one_malformed_pdf_does_not_block_an_independent_valid_pdf(self) -> None:
+        model = RestoreModel({"pdf-a": [{"id": "old-a"}], "pdf-b": [{"id": "old-b"}]})
+        malformed = Snapshot("pdf-a", 3, (PageSnapshot(0, ("not-json",)),))
+
+        model.restore([malformed, snapshot("pdf-b", 3, "new-b")])
+
+        self.assertEqual(model.documents["pdf-a"], [{"id": "old-a"}])
+        self.assertEqual(model.documents["pdf-b"], [{"id": "new-b", "pageIndex": 0}])
+
+    def test_dirty_document_rejects_remote_replacement(self) -> None:
+        model = RestoreModel({"pdf-a": [{"id": "local-unsaved"}]})
+        model.mark_dirty("pdf-a")
+
+        model.restore([snapshot("pdf-a", 20, "remote")])
+
+        self.assertEqual(model.documents["pdf-a"], [{"id": "local-unsaved"}])
+
+    def test_stale_and_equal_conflicting_versions_preserve_newer_local_snapshot(self) -> None:
+        local = snapshot("pdf-a", 20, "local")
+        model = RestoreModel({"pdf-a": [{"id": "local", "pageIndex": 0}]})
+        model.record_local(local)
+
+        model.restore([snapshot("pdf-a", 19, "stale")])
+        model.restore([snapshot("pdf-a", 20, "same-second-conflict")])
+
+        self.assertEqual(model.documents["pdf-a"], [{"id": "local", "pageIndex": 0}])
+
+    def test_explicit_empty_snapshot_clears_only_matching_pdf(self) -> None:
+        model = RestoreModel({"pdf-a": [{"id": "a"}], "pdf-b": [{"id": "b"}]})
+
+        model.restore([Snapshot("pdf-a", 2, ())])
+
+        self.assertEqual(model.documents["pdf-a"], [])
+        self.assertEqual(model.documents["pdf-b"], [{"id": "b"}])
+
+    def test_duplicate_page_and_page_mismatch_are_rejected_before_swap(self) -> None:
+        duplicate_page = Snapshot(
+            "pdf-a",
+            2,
+            (PageSnapshot(0, (annotation("one"),)), PageSnapshot(0, (annotation("two"),))),
+        )
+        mismatch = Snapshot("pdf-a", 3, (PageSnapshot(1, (annotation("wrong", 0),)),))
+
+        for malformed in (duplicate_page, mismatch):
+            with self.subTest(malformed=malformed):
+                model = RestoreModel({"pdf-a": [{"id": "visible"}]})
+                model.restore([malformed])
+                self.assertEqual(model.documents["pdf-a"], [{"id": "visible"}])
+
+
+class ProductionSourceTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.source = load_production_source(SOURCE_PATH)
+        cls.controller_source = load_production_source(CONTROLLER_SOURCE_PATH)
+
+    def test_restore_is_coordinator_scoped_and_tracks_dirty_documents(self) -> None:
+        self.assertIn("PDFAnnotationRestoreState", self.source)
+        self.assertIn("markDirty(pdfId:", self.source)
+        self.assertIn("recordLocalSnapshot", self.source)
+        self.assertIn(".PSPDFAnnotationsAdded", self.source)
+        self.assertIn(".PSPDFAnnotationsRemoved", self.source)
+        self.assertIn(".PSPDFAnnotationChanged", self.source)
+
+    def test_controller_does_not_retain_its_coordinator_delegate(self) -> None:
+        self.assertIn("protocol PDFAuxiliaryViewControllerDelegate: AnyObject", self.controller_source)
+        self.assertIn(
+            "weak var pdfAuxiliaryViewControllerDelegate: PDFAuxiliaryViewControllerDelegate?",
+            self.controller_source,
+        )
+
+    def test_restore_stages_and_validates_before_document_mutation(self) -> None:
+        stage_call = self.source.index("stageReplacement(for:")
+        remove_call = self.source.index("document.remove(annotations:", stage_call)
+        self.assertLess(stage_call, remove_call)
+        self.assertIn("seenPageIndices.insert", self.source)
+        self.assertIn("Int(decodedAnnotation.pageIndex) == pageSnapshot.pageIndex", self.source)
+
+    def test_sdk_swap_failures_attempt_to_restore_the_previous_snapshot(self) -> None:
+        self.assertIn(
+            "guard document.remove(annotations: currentAnnotations, options: .none)",
+            self.source,
+        )
+        self.assertIn("guard document.add(annotations: replacement, options: nil)", self.source)
+        self.assertIn("restoreOriginalAnnotations(currentAnnotations, in: document)", self.source)
+        self.assertIn("PDFAnnotationRestoreError.rollbackFailed", self.source)
+
+    def test_restore_has_no_forced_utf8_or_instant_json_decoding(self) -> None:
+        self.assertNotIn("data(using: .utf8)!", self.source)
+        self.assertNotIn("try!", self.source)
+        restore_start = self.source.index("func stageReplacement(")
+        restore_end = self.source.index("func saveUserInput(", restore_start)
+        restore_source = self.source[restore_start:restore_end]
+        self.assertNotIn("try!", restore_source)
+        self.assertIn("guard let annotationData = serializedAnnotation.data(using: .utf8)", restore_source)
+
+    def test_global_annotation_wipe_pattern_is_removed(self) -> None:
+        self.assertNotIn("documents.forEach { document in", self.source)
+        self.assertIn("guard let target = restoreTarget(for: candidate.pdfId)", self.source)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/Scripts/validate_pdf_annotation_restore.py
+++ b/Scripts/validate_pdf_annotation_restore.py
@@ -48,6 +48,7 @@ class PageSnapshot:
 @dataclasses.dataclass(frozen=True)
 class Snapshot:
     pdf_id: str
+    block_id: str
     timestamp: int
     pages: tuple[PageSnapshot, ...]
 
@@ -134,6 +135,7 @@ def annotation(annotation_id: str, page_index: int = 0) -> str:
 def snapshot(pdf_id: str, timestamp: int, *annotation_ids: str) -> Snapshot:
     return Snapshot(
         pdf_id=pdf_id,
+        block_id=pdf_id,
         timestamp=timestamp,
         pages=(PageSnapshot(0, tuple(annotation(value) for value in annotation_ids)),),
     )
@@ -158,7 +160,7 @@ class RestoreContractTests(unittest.TestCase):
 
     def test_malformed_snapshot_preserves_last_known_good(self) -> None:
         model = RestoreModel({"pdf-a": [{"id": "visible"}]})
-        malformed = Snapshot("pdf-a", 3, (PageSnapshot(0, ("not-json",)),))
+        malformed = Snapshot("pdf-a", "pdf-a", 3, (PageSnapshot(0, ("not-json",)),))
 
         model.restore([malformed])
 
@@ -167,7 +169,7 @@ class RestoreContractTests(unittest.TestCase):
 
     def test_one_malformed_pdf_does_not_block_an_independent_valid_pdf(self) -> None:
         model = RestoreModel({"pdf-a": [{"id": "old-a"}], "pdf-b": [{"id": "old-b"}]})
-        malformed = Snapshot("pdf-a", 3, (PageSnapshot(0, ("not-json",)),))
+        malformed = Snapshot("pdf-a", "pdf-a", 3, (PageSnapshot(0, ("not-json",)),))
 
         model.restore([malformed, snapshot("pdf-b", 3, "new-b")])
 
@@ -195,7 +197,7 @@ class RestoreContractTests(unittest.TestCase):
     def test_explicit_empty_snapshot_clears_only_matching_pdf(self) -> None:
         model = RestoreModel({"pdf-a": [{"id": "a"}], "pdf-b": [{"id": "b"}]})
 
-        model.restore([Snapshot("pdf-a", 2, ())])
+        model.restore([Snapshot("pdf-a", "pdf-a", 2, ())])
 
         self.assertEqual(model.documents["pdf-a"], [])
         self.assertEqual(model.documents["pdf-b"], [{"id": "b"}])
@@ -203,16 +205,37 @@ class RestoreContractTests(unittest.TestCase):
     def test_duplicate_page_and_page_mismatch_are_rejected_before_swap(self) -> None:
         duplicate_page = Snapshot(
             "pdf-a",
+            "pdf-a",
             2,
             (PageSnapshot(0, (annotation("one"),)), PageSnapshot(0, (annotation("two"),))),
         )
-        mismatch = Snapshot("pdf-a", 3, (PageSnapshot(1, (annotation("wrong", 0),)),))
+        mismatch = Snapshot(
+            "pdf-a",
+            "pdf-a",
+            3,
+            (PageSnapshot(1, (annotation("wrong", 0),)),),
+        )
 
         for malformed in (duplicate_page, mismatch):
             with self.subTest(malformed=malformed):
                 model = RestoreModel({"pdf-a": [{"id": "visible"}]})
                 model.restore([malformed])
                 self.assertEqual(model.documents["pdf-a"], [{"id": "visible"}])
+
+    def test_cross_id_snapshot_is_rejected_without_mutation(self) -> None:
+        model = RestoreModel({"pdf-a": [{"id": "visible-a"}], "pdf-b": [{"id": "visible-b"}]})
+        cross_id = Snapshot(
+            pdf_id="pdf-a",
+            block_id="pdf-b",
+            timestamp=4,
+            pages=(PageSnapshot(0, (annotation("wrong-document"),)),),
+        )
+
+        model.restore([cross_id])
+
+        self.assertEqual(model.documents["pdf-a"], [{"id": "visible-a"}])
+        self.assertEqual(model.documents["pdf-b"], [{"id": "visible-b"}])
+        self.assertNotIn("pdf-a", model.accepted)
 
 
 class ProductionSourceTests(unittest.TestCase):
@@ -264,6 +287,9 @@ class ProductionSourceTests(unittest.TestCase):
     def test_global_annotation_wipe_pattern_is_removed(self) -> None:
         self.assertNotIn("documents.forEach { document in", self.source)
         self.assertIn("guard let target = restoreTarget(for: candidate.pdfId)", self.source)
+
+    def test_restore_rejects_cross_id_annotation_records(self) -> None:
+        self.assertIn("candidate.blockId == candidate.pdfId", self.source)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Draft PR packet: ADV-2026-0008

## Proposed PR

- Suggested title: `fix: preserve PDF annotations during restore`
- Upstream target: `Adventech/sabbath-school-ios` / `dev`
- Audited and last revalidated public base: `058426befc396279f3e8dca52b2a1bd8aad641eb`
- Published fork branch: `fix/adv-2026-0008-pdf-annotation-restore-refresh`
- Local final head: `df5b68d33c0bdd8f52906bb484b409379070380c`
- Local final tree: `2a769b232a6aba25aabe44c82bf96b6bc0bbe433`
- Shape: three commits from the base - historical functional fix `5e4c631a`, expanded red `a1b2b6bf`, final fix `df5b68d3`; one root only (`RC-0008`)
- Superseded evidence ref: `fix/adv-2026-0008-pdf-annotation-restore` at `712e09e87b5a57782e89256588f0d31ca78db1b5`; never publish it separately
- State: published as draft PR [#199](https://github.com/Adventech/sabbath-school-ios/pull/199) from the authorized personal fork; not merged or deployed.

Publication privacy note: all three branch commits were recreated with the account's GitHub noreply identity. Their source trees, messages, equivalent parent trees, and patches are unchanged.

## Why

Every global input-array emission reached the PDF restore path. The base removed annotations from every open PDF before selecting a matching `pdfId` or validating Instant JSON, and swallowed per-item decode errors. A comment update, unrelated PDF, empty array, malformed payload, or autosave echo could therefore clear complete visible annotations. This is a confirmed P0 contributor to iOS #176 and the annotation portion of lessons #4110.

## Failing-before reproduction

Open PDFs A and B with annotations, then emit a non-PDF update, an annotation for PDF C, or an empty global array. The base clears A and B and restores neither. Alternatively, supply a matching payload with one malformed item; clear happens first and the caught decode error leaves an empty/partial document.

```powershell
$env:PDF_ANNOTATION_RESTORE_SOURCE_REF='058426befc396279f3e8dca52b2a1bd8aad641eb'
python -I Scripts/validate_pdf_annotation_restore.py
```

The base replay exits 1 with five failures and one error: global wipe and forced decoding remain, there is no dirty/last-known-good state or staged boundary, rollback is absent, and delegate ownership is unsafe. Published first fix `5e4c631a` passes the original 14/14 corpus, but expanded regression `a1b2b6bf` supplies mismatched `blockId`/`pdfId` identity and is expected-red at 15/16 (one failing production-source test). Final `df5b68d3` passes 16/16.

## Minimal fix

- Move restore/autosave ownership into the long-lived coordinator.
- Select only the newest unambiguous annotation record for PDFs displayed by that controller; no match means no mutation.
- Require each candidate's existing `blockId` and `pdfId` to agree before selection; cross-identity snapshots are ignored.
- Track per-document dirty/last-known-good state and suppress programmatic restore callbacks.
- Fully validate identity, pages, UTF-8, Instant JSON, and decoded page association before removal.
- Replace only the addressed PDF; check SDK add/remove results and reconstruct the original objects on a partial failure.
- Keep an explicit matching empty snapshot as a valid delete-all, while an empty global array is a no-op.
- Make the delegate class-bound/weak and preserve existing payload/ID/timestamp shapes.

## Recorded local checks

- Expected RED on exact base blobs: 5 failures and 1 error.
- Historical-equivalent PASS at published `5e4c631a`: original 14/14 model/source checks.
- Expanded expected RED at published `a1b2b6bf` (tree `ec203f5a`): 15/16 with one failing production-source test, proving the missing production identity guard.
- PASS at published final `df5b68d3` (tree `2a769b23`): expanded 16/16 model/source checks.
- PASS: Python syntax, exact pinned PSPDFKit 14.2.1 API/Boolean-contract inspection, diff check, three-commit one-root distance, and clean tree.
- PASS: pairwise merge trees with RC-0005 and RC-0007.
- PASS in verification-only refreshed stacks: P0 head `226d1459` (tree `72eba236`) is 43/43; full six-suite head `1b6d191f` (tree `cad134b0`) is 71/71; refresh patch-id `22fe62e920ad257e2b14d04ed459fb2ddf6061d2` is identical in both.

These are Windows-hosted source/model and read-only API-inspection results. No Swift compilation, SwiftLint, XCTest, licensed PSPDFKit runtime, simulator, physical-device, hosted Actions, signing, store, or production result is claimed.

## Overlap and disposition

Current iOS PRs #190 (`11b5723be159c7f758e39f97be8eba81eb0634a2`), #192 (`bcf3970e63b122ece9a32a5b9c7dc5a2b07ea0be`), and #193's intended retargeted `dev`-relative delta have zero file overlap with this root. The connector's complete configured #193 file list contains 2,093 entries; the local rename-aware triple-dot comparison reports 2,060 changed paths after collapsing 33 rename pairs. That obsolete-`master` comparison has misleading technical overlap, so it is not a zero-overlap proof. Preserve their supersede/split/rebase dispositions.

RC-0008 is file-disjoint from RC-0005 and RC-0007. Keep it separate. The final release must combine their semantics: RC-0005 prevents stale remote replacement, RC-0007 makes autosave durable, and this root prevents destructive live restore. Do not directly merge the refreshed branch onto old stack `df3e48d`: that stack already contains a cherry-picked tree-equivalent of `5e4c631a` without ancestral identity. Apply only refresh delta `5e4c631a..df5b68d3`, as proven by the identical verification patch-id; never publish either verification head wholesale.

## Migration, recovery, and rollback

- No stored/wire migration; existing `UserInputAnnotation` and Instant JSON shapes remain compatible.
- Unrelated/malformed/dirty/older/equal-conflicting candidates leave live annotations untouched; an explicit addressed empty snapshot clears only that PDF.
- Process death before the SDK emits autosave remains outside this root; durability after autosave depends on RC-0007.
- Previously cleared annotations require a trusted local/server backup and private conflict comparison.
- A revert is schema-compatible but restores global clear-before-validate. Before rollback, prove snapshots are durable/synced, preserve cache bytes, and disable live remote reload if the guarded path cannot remain.

## Security, privacy, and content rights

Fixtures are synthetic. Diagnostics must not include Instant JSON, note text, credentials, document bytes, or user data. This root adds no recipient, telemetry, external storage, translation, lesson, PDF/video asset, Bible/EGW material, signing, or deployment change.

## Dependency order and draft blockers

Review independently, then retest with RC-0007 and RC-0005 in that dependency order. After publication from an authorized personal fork, keep the PR draft until locked packages compile on macOS; SwiftLint/XCTest pass; licensed PSPDFKit tests cover multiple PDFs, unrelated emissions, malformed/page-invalid payloads, SDK mutation/rollback failure, dirty/stale input, final deletion, downloading PDFs, built-in/form annotations, lifecycle/process kill, offline relaunch, upgrade/downgrade, and required hosted checks. Use synthetic data only.
