### PR TITLE
fix(ios): canonicalize the Nuke SwiftPM URL

### DIFF
--- a/Sabbath School.xcodeproj/project.pbxproj
+++ b/Sabbath School.xcodeproj/project.pbxproj
@@ -2746,7 +2746,7 @@
 		};
 		2F7526602CCB09890027FD1E /* XCRemoteSwiftPackageReference "Nuke" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/kean/Nuke?tab=readme-ov-file";
+			repositoryURL = "https://github.com/kean/Nuke.git";
 			requirement = {
 				kind = exactVersion;
 				version = 12.8.0;

--- a/Sabbath School.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Sabbath School.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -74,9 +74,9 @@
       }
     },
     {
-      "identity" : "nuke?tab=readme-ov-file",
+      "identity" : "nuke",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/kean/Nuke?tab=readme-ov-file",
+      "location" : "https://github.com/kean/Nuke.git",
       "state" : {
         "revision" : "0ead44350d2737db384908569c012fe67c421e4d",
         "version" : "12.8.0"

--- a/Scripts/validate_swift_package_references.py
+++ b/Scripts/validate_swift_package_references.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Validate the canonical Nuke Swift Package Manager reference."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from urllib.parse import urlsplit
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+PROJECT_FILE = REPOSITORY_ROOT / "Sabbath School.xcodeproj" / "project.pbxproj"
+RESOLVED_FILE = (
+    REPOSITORY_ROOT
+    / "Sabbath School.xcodeproj"
+    / "project.xcworkspace"
+    / "xcshareddata"
+    / "swiftpm"
+    / "Package.resolved"
+)
+
+NUKE_URL = "https://github.com/kean/Nuke.git"
+NUKE_IDENTITY = "nuke"
+NUKE_REVISION = "0ead44350d2737db384908569c012fe67c421e4d"
+NUKE_VERSION = "12.8.0"
+
+
+def is_nuke_location(value: object) -> bool:
+    if not isinstance(value, str):
+        return False
+
+    parsed = urlsplit(value)
+    path = parsed.path.rstrip("/")
+    if path.lower().endswith(".git"):
+        path = path[:-4]
+    return parsed.netloc.lower() == "github.com" and path.lower() == "/kean/nuke"
+
+
+def main() -> int:
+    errors: list[str] = []
+
+    project = PROJECT_FILE.read_text(encoding="utf-8")
+    repository_urls = re.findall(r'repositoryURL = "([^"]+)";', project)
+    project_nuke_urls = [url for url in repository_urls if is_nuke_location(url)]
+    if project_nuke_urls != [NUKE_URL]:
+        errors.append(
+            f"{PROJECT_FILE.relative_to(REPOSITORY_ROOT)} must reference Nuke once as "
+            f"{NUKE_URL!r}; found {project_nuke_urls!r}"
+        )
+
+    resolved = json.loads(RESOLVED_FILE.read_text(encoding="utf-8"))
+    pins = resolved.get("pins", [])
+    nuke_pins = [
+        pin
+        for pin in pins
+        if isinstance(pin, dict)
+        and (
+            str(pin.get("identity", "")).partition("?")[0].lower() == NUKE_IDENTITY
+            or is_nuke_location(pin.get("location"))
+        )
+    ]
+
+    if len(nuke_pins) != 1:
+        errors.append(
+            f"{RESOLVED_FILE.relative_to(REPOSITORY_ROOT)} must contain exactly one "
+            f"Nuke pin; found {len(nuke_pins)}"
+        )
+    else:
+        pin = nuke_pins[0]
+        state = pin.get("state", {})
+        expected_values = {
+            "identity": (pin.get("identity"), NUKE_IDENTITY),
+            "location": (pin.get("location"), NUKE_URL),
+            "revision": (state.get("revision"), NUKE_REVISION),
+            "version": (state.get("version"), NUKE_VERSION),
+        }
+        for field, (actual, expected) in expected_values.items():
+            if actual != expected:
+                errors.append(
+                    f"Nuke {field} must remain {expected!r}; found {actual!r}"
+                )
+
+    if errors:
+        print("Swift package reference validation failed:", file=sys.stderr)
+        for error in errors:
+            print(f" - {error}", file=sys.stderr)
+        return 1
+
+    print(
+        f"Swift package reference validation passed: Nuke {NUKE_VERSION} "
+        f"at {NUKE_REVISION}."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Audit: `ADV-2026-0035` / `RC-0035`

## Root cause

The Xcode project and `Package.resolved` store a GitHub README page URL, including `?tab=readme-ov-file`, as Nuke's SwiftPM repository URL and identity. Git appends `/info/refs` after that query and rejects the result, so a cache-cold dependency resolution cannot use the configured source.

## Regression-first fix

- Audited base: `058426befc396279f3e8dca52b2a1bd8aad641eb`
- Head: `b46b1ff70a10092c03e54091184cc41e0bc69392`
- Shape: one commit, one root, 3 files, +102/-3

The fix changes the source to `https://github.com/kean/Nuke.git`, normalizes the resolved identity to `nuke`, and preserves the exact Nuke `12.8.0` revision `0ead44350d2737db384908569c012fe67c421e4d`.

## Recorded evidence

- Exact malformed URL: `git ls-remote` exits 128 with invalid `info/refs`
- Canonical tag lookup: exits 0 and returns the already locked revision
- Regression validator: fails on the exact base and passes at the head
- Python syntax, resolved JSON, URL/count, bad-suffix, translation-scope, diff, ancestry, and clean-tree checks: pass
- All seven live iOS PRs (#190, #192, #193, #196-#199): zero actual `dev`-relative file overlap and clean pairwise merge-tree composition

PR #193 still targets obsolete `master`; its intended `dev` delta is only two localization files and its package files are byte-identical to `dev`.

No dependency version, runtime code, stored data, schema, signing material, translation, or rights-controlled content changes are included.

## Draft gates

Windows cannot provide Xcode evidence. Keep this draft until a supported macOS/Xcode runner performs a cache-cold locked resolution, proves Xcode leaves the resolved pin unchanged, builds the `Sabbath School` scheme for an unsigned simulator, reruns the validator, and finishes with a clean tree.

Frozen `dev` also points its shared scheme at a deleted `SnapshotUITests` target. Package resolution and the unsigned app build can validate this root independently, but meaningful XCTest must wait for the source-disjoint ADV-0063 replacement target and test plan. This root should precede the separate iOS CI and replacement-test-target roots.

Rollback: revert this commit only if Xcode exposes an unexpected canonicalization problem; hold the last known-good built artifact instead of restoring the confirmed malformed URL.